### PR TITLE
Create `client-docker.yml` Github Action for CI testing of Teamserver Client

### DIFF
--- a/.github/workflows/client-docker.yml
+++ b/.github/workflows/client-docker.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file ./Client/Client-Dockerfile . --tag havoc-client:$(date +%s)


### PR DESCRIPTION
This `client-docker.yml` file adds the Github action of compiling the 'Havoc/Client/Client-Dockerfile' dockerfile on each pull request.

This can act as a canary for integration testing of the Teamserver client.