### PR TITLE
Create docker-teamserver-CI.yml

### DIFF
--- a/.github/workflows/docker-teamserver-CI.yml
+++ b/.github/workflows/docker-teamserver-CI.yml
@@ -1,0 +1,18 @@
+name: Docker Image CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build the Docker image
+      run: docker build . --file ./Teamserver/Teamserver-Dockerfile --tag havoc-teamserver:$(date +%s)

--- a/Client/README.md
+++ b/Client/README.md
@@ -7,7 +7,8 @@ Havoc Gui Client source code.
 	1. `Python-3.10`
 	2. `python3-dev`
 	3. `libspdlog-dev`
-	4. `qt5`-packages
+	4. `qt5`& related packages
+		* `libfontconfig1` `libglu1-mesa-dev` `libgtest-dev` `libspdlog-dev` `libboost-all-dev` `mesa-common-dev` `qtbase5-dev` `qtchooser` `qt5-qmake` `qtbase5-dev-tools` `libqt5websockets5` `libqt5websockets5-dev` `qtdeclarative5-dev`
 	5. `libboost-all-dev`
 - **Local Build**
 	- To build the Teamserver Client locally, perform the following steps:

--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -23,7 +23,7 @@ Source code of Havoc teamserver. Written in Golang.
 - **Jenkins Docker**
 	- We can also build the Teamserver binary using a pre-configured Jenkins Docker image.
 		1. From the parent folder(`Havoc`), run the following command to build the container:
-			* `sudo docker build -t jenkins-havoc-teamserver -f JT-Dockerfile .``
+			* `sudo docker build -t jenkins-havoc-teamserver -f JT-Dockerfile .`
 		2. (Optionally) Create a persistent data volume for the container:
 			* `sudo docker volume create havoc-cicd-c2-data`
 		2. Next, we want to run the container:
@@ -42,7 +42,7 @@ Source code of Havoc teamserver. Written in Golang.
 - **Docker**
 	- We can run the teamserver completely from within a container!
 	1. Build the container: 
-		* `sudo docker build -f Client-Dockerfile .`
+		* `sudo docker build -t havoc-teamserver -f Client-Dockerfile .`
 	2. Launch the container (be sure to change the port mapping to match your environment):
-		* `sudo docker run -p40056:40056 -p 443:443 -it -d -v havoc-c2-data:/data jenkins-havoc-client`
+		* `sudo docker run -p40056:40056 -p 443:443 -it -d -v havoc-c2-data:/data havoc-teamserver`
 	3. Access the teamserver at `localhost:40056` using your Teamserver client.

--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -5,8 +5,8 @@ Source code of Havoc teamserver. Written in Golang.
 
 ### Build the Teamserver
 - **Pre-requisites**
-	1. Go1.19
-	2. f
+	1. Go1.18
+	2. <fixme>
 - **Native**
 	- To build the Teamserver client locally, run the following command in this folder(`~/Havoc/Teamserver/`):
 		1. `make`

--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -19,7 +19,7 @@ Source code of Havoc teamserver. Written in Golang.
 		2. (Optional) Create a persistent data volume for the container:
 			* `sudo docker volume create havoc-c2-data`
 		3. Run the container:
-			* `sudo docker run -p8080:8080 -it -d -v havoc-c2-data:/data havoc-teamserver`
+			* `sudo docker run -it -d -v havoc-c2-data:/data havoc-teamserver`
 - **Jenkins Docker**
 	- We can also build the Teamserver binary using a pre-configured Jenkins Docker image.
 		1. From the parent folder(`Havoc`), run the following command to build the container:

--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -5,8 +5,9 @@ Source code of Havoc teamserver. Written in Golang.
 
 ### Build the Teamserver
 - **Pre-requisites**
-	1. Go1.18
-	2. <fixme>
+	1. Go1.19
+	2. Other packages: `dh-golang` `golang-go` `mingw-64` `nasm` `dh-make`
+	3. `make` - Version `3.24.1` was observed to work with debian.
 - **Native**
 	- To build the Teamserver client locally, run the following command in this folder(`~/Havoc/Teamserver/`):
 		1. `make`

--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -20,6 +20,8 @@ Source code of Havoc teamserver. Written in Golang.
 			* `sudo docker volume create havoc-c2-data`
 		3. Run the container:
 			* `sudo docker run -it -d -v havoc-c2-data:/data havoc-teamserver`
+		4. If you would like to extract the compiled binary to your local system, the following command may be used:
+			* `sudo docker cp <container_id>:/path/to/binary .` to copy your designated file to your local directory.
 - **Jenkins Docker**
 	- We can also build the Teamserver binary using a pre-configured Jenkins Docker image.
 		1. From the parent folder(`Havoc`), run the following command to build the container:


### PR DESCRIPTION
This adds an integration test to compile the Teamserver Dockerfile upon pull requests to the `main` branch.
It is expected that the build will fail currently. This is a place holder until the repo is made public.