### PR TITLE
Updated Teamserver Readme & Wiki to note '--default' flag on startup

### DIFF
--- a/Teamserver/README.md
+++ b/Teamserver/README.md
@@ -38,11 +38,13 @@ Source code of Havoc teamserver. Written in Golang.
 - **Manual:**
 	- The teamserver can also be used directly:
 		* `./bin/teamserver -h`
-		* `./bin/teamserver server --profile profiles/havoc.yaotl -v`
+		* `./bin/teamserver server --default --verbose`
 - **Docker**
 	- We can run the teamserver completely from within a container!
 	1. Build the container: 
 		* `sudo docker build -f Client-Dockerfile .`
 	2. Launch the container (be sure to change the port mapping to match your environment):
 		* `sudo docker run -p40056:40056 -p 443:443 -it -d -v havoc-c2-data:/data jenkins-havoc-client`
+	3. Enter the container and launch the teamserver binary:
+		* `sudo docker exec -t <container_id> "/go/Build/bin/teamserver"`
 	3. Access the teamserver at `localhost:40056` using your Teamserver client.

--- a/WIKI.MD
+++ b/WIKI.MD
@@ -123,7 +123,7 @@ The Havoc Teamserver is written in Golang. It handles the listeners, teamserver 
 
 Running `./teamserver` will automatically build the Teamserver, set it as executable and start it with the following options:
 
-`./bin/teamserver server --profile profiles/havoc.yaotl -v`
+`./bin/teamserver server --default --verbose`
 
 ### <a name="targ"></a>Arguments
 


### PR DESCRIPTION
Update documentation to address https://github.com/HavocFramework/Havoc/issues/77.
Specifically, add the `--default` startup flag to the WIKI.md and `README.md` in the Teamserver directory.