### PR TITLE
add macOS support for client && fix .gitignore to ignore binaries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,5 @@ Client/Data/database.db
 Teamserver/go.sum
 
 # ignore compiled binaries
-*/Client/Havoc
-*/Teamserver/teamserver
+Client/Havoc
+Teamserver/teamserver

--- a/Client/Build.sh
+++ b/Client/Build.sh
@@ -1,4 +1,4 @@
-mkdir Build
+mkdir -p Build
 cd Build
 cmake ..
 cd ..

--- a/Client/CMakeLists.txt
+++ b/Client/CMakeLists.txt
@@ -16,7 +16,15 @@ set( REQUIRED_LIBS Core Gui Widgets Network WebSockets Sql )
 set( REQUIRED_LIBS_QUALIFIED Qt5::Core Qt5::Gui Qt5::Widgets Qt5::Network Qt5::WebSockets Qt5::Sql )
 
 include_directories( Include )
-include_directories( "/usr/include/python3.10" )
+
+if(APPLE)
+    execute_process(COMMAND brew --prefix OUTPUT_VARIABLE BREW_PREFIX) #this because brew install location differs Intel/Apple Silicon macs
+    string(STRIP ${BREW_PREFIX} BREW_PREFIX) #for some reason this happens: https://gitlab.kitware.com/cmake/cmake/-/issues/22404
+    include_directories( "${BREW_PREFIX}/bin/python3.10" )
+    include_directories( "${BREW_PREFIX}/Frameworks/Python.framework/Headers" )
+elseif(UNIX)
+    include_directories( "/usr/include/python3.10" )
+endif()
 
 set( APP_ICON_RESOURCE_WINDOWS "${CMAKE_CURRENT_SOURCE_DIR}/Havoc.qrc" )
 
@@ -156,7 +164,20 @@ add_definitions( -DQT_NO_DEBUG_OUTPUT )
 
 set( Python_ADDITIONAL_VERSIONS )
 
-find_package( PythonLibs REQUIRED )
+if(APPLE)
+  find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
+  set(PYTHON_MAJOR $ENV{Python_VERSION_MAJOR})
+  set(PYTHON_MINOR $ENV{Python_VERSION_MINOR})
+  set(PYTHONLIBS_VERSION_STRING ${Python_VERSION})
+  set(PYTHON_INCLUDE_DIR ${Python_INCLUDE_DIRS})
+  set(PYTHON_LIBRARIES ${Python_LIBRARIES})
+  message("Apple - Using Python:${Python_VERSION_MAJOR} - Libraries:${PYTHON_LIBRARIES} - IncludeDirs: ${PYTHON_INCLUDE_DIR}")
+elseif(UNIX)
+  find_package(PythonLibs 3 REQUIRED)
+else()
+  set(PYTHONLIBS_VERSION_STRING $ENV{PY_VERSION})
+endif()
+
 find_package( spdlog REQUIRED )
 find_package( Qt${QT_VERSION} COMPONENTS ${REQUIRED_LIBS} REQUIRED )
 

--- a/WIKI.MD
+++ b/WIKI.MD
@@ -81,7 +81,7 @@ You probably need a newer version of Qt. If you are using Ubuntu try adding a ba
 ### <a name="il"></a> Local
 
 #### Pre-requisites
-
+> The immediate following is for Debian based Distros only.
 ```
 sudo apt install -y git build-essential apt-utils cmake libfontconfig1 libglu1-mesa-dev libgtest-dev libspdlog-dev libboost-all-dev libncurses5-dev libgdbm-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev libbz2-dev mesa-common-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5websockets5 libqt5websockets5-dev qtdeclarative5-dev golang-go qtbase5-dev libqt5websockets5-dev libspdlog-dev python3-dev libboost-all-dev mingw-w64 nasm
 ```
@@ -106,7 +106,14 @@ echo 'deb http://ftp.de.debian.org/debian bookworm main' >> /etc/apt/sources.lis
 sudo apt update
 sudo apt install python3-dev python3.10-dev libpython3.10 libpython3.10-dev python3.10
 ```
+#### MacOS
 
+> You must have [`homebrew`](https://brew.sh) installed.
+```
+brew install --cask cmake
+brew install python@3.10 qt@5 spdlog golang
+brew link --overwrite qt@5
+```
 ### <a name="bclient"></a>Building the Client
 
 > If you are using a debian-based distro, you can use the bundled installation script at `/Havoc/Client/Install.sh`. 
@@ -125,6 +132,7 @@ cd Havoc/Client
 ```
 
 Running `Havoc` will start the Client. 
+> On macOS, run `brew unlink qt && brew link qt` after cmake build is done.
 
 ### <a name="bteam"></a>Building the Teamserver
 


### PR DESCRIPTION
I'm on Macbook Pro M1 Pro chip
the pull https://github.com/HavocFramework/Havoc/pull/127 was unsuccessful and .gitignore was messy hence this pull req

patches to the CMakeLists.txt for compatibility with macOS
```diff
25c25,33
< include_directories( "/usr/include/python3.10" )
---
> 
> if(APPLE)
>     execute_process(COMMAND brew --prefix OUTPUT_VARIABLE BREW_PREFIX) #this because brew install location differs Intel/Apple Silicon macs
>     string(STRIP ${BREW_PREFIX} BREW_PREFIX) #for some reason this happens: https://gitlab.kitware.com/cmake/cmake/-/issues/22404
>     include_directories( "${BREW_PREFIX}/bin/python3.10" )
>     include_directories( "${BREW_PREFIX}/Frameworks/Python.framework/Headers" )
> elseif(UNIX)
>     include_directories( "/usr/include/python3.10" )
> endif()
165c173,186
< find_package( PythonLibs REQUIRED )
---
> if(APPLE)
>   find_package(Python 3 COMPONENTS Interpreter Development REQUIRED)
>   set(PYTHON_MAJOR $ENV{Python_VERSION_MAJOR})
>   set(PYTHON_MINOR $ENV{Python_VERSION_MINOR})
>   set(PYTHONLIBS_VERSION_STRING ${Python_VERSION})
>   set(PYTHON_INCLUDE_DIR ${Python_INCLUDE_DIRS})
>   set(PYTHON_LIBRARIES ${Python_LIBRARIES})
>   message("Apple - Using Python:${Python_VERSION_MAJOR} - Libraries:${PYTHON_LIBRARIES} - IncludeDirs: ${PYTHON_INCLUDE_DIR}")
> elseif(UNIX)
>   find_package(PythonLibs 3 REQUIRED)
> else()
>   set(PYTHONLIBS_VERSION_STRING $ENV{PY_VERSION})
> endif()
> 
```

little improvement on the mkdir 🗿 in Client/Build.sh
```diff
1c1
< mkdir Build
---
> mkdir -p Build
```

Added macos instructions to and cleaned up WIKI.md
```diff
83a84
> > The immediate following is for Debian based Distros only.
109a111,120
> #### MacOS
> 
> > You must have [`homebrew`](https://brew.sh) installed.
> 
> ```
> brew install --cask cmake
> brew install python@3.10 qt@5 spdlog golang
> brew brew link --overwrite qt@5
> ```
> 
123,127c134
< mkdir Build
< cd Build
< cmake ..
< cd ..
< ./Havoc.sh
---
> sh Build.sh
128a136
> > On macOS, run `brew unlink qt && brew link qt` after cmake build is done.
130c138
< Running `Havoc.sh` will automatically build the Client and start it. 
---
> Running `Build.sh` will automatically build the Client. 
```

**Lastly**, fix .gitignore; the binaries were **not** being ignored
```diff
22,23c22,23
< */Client/Havoc
< */Teamserver/teamserver
---
> Client/Havoc
> Teamserver/teamserver
```

Cheers. 🤌🏻