### PR TITLE
Incorrect Build command for client

### DIFF
--- a/WIKI.MD
+++ b/WIKI.MD
@@ -124,7 +124,7 @@ mkdir Build
 cd Build
 cmake ..
 cd ..
-./Havoc.sh
+./Install.sh
 ```
 
 Running `Havoc.sh` will automatically build the Client and start it. 


### PR DESCRIPTION
Havoc.sh wasn't existent after running cmake, ./Install.sh had to be run instead. [@line 127]