### PR TITLE
Fix Issue #135 - error: incomplete type ‘QDate’ used in nested name specified 

### DIFF
--- a/Client/Source/UserInterface/Widgets/DemonInteracted.cpp
+++ b/Client/Source/UserInterface/Widgets/DemonInteracted.cpp
@@ -1,7 +1,7 @@
 #include <global.hpp>
 #include <UserInterface/Widgets/DemonInteracted.h>
 #include <Util/ColorText.h>
-
+#include <QTime>
 #include <QCompleter>
 #include <QKeyEvent>
 #include <QEvent>


### PR DESCRIPTION
Added the header file `QTime` to fix the issue