### PR TITLE
Update Chat.cpp

### DIFF
--- a/Client/Source/UserInterface/Widgets/Chat.cpp
+++ b/Client/Source/UserInterface/Widgets/Chat.cpp
@@ -67,9 +67,9 @@ void HavocNamespace::UserInterface::Widgets::Chat::AppendText(const QString& Tim
 void HavocNamespace::UserInterface::Widgets::Chat::AddUserMessage(const QString Time, QString User, QString text) const
 {
     if ( HavocX::Teamserver.User.compare( User ) == 0 )
-        this->AppendText( Time, "[" + Util::ColorText::UnderlineGreen( User ) + "]" + Util::ColorText::Bold(" :: ") + text.toHtmlEscaped() );
+        this->AppendText( Time, "[" + Util::ColorText::UnderlineGreen( User ) + "]" + Util::ColorText::Bold(" :: ") + text );
     else
-        this->AppendText( Time, "[" + Util::ColorText::Underline( User ) + "]" + Util::ColorText::Bold(" :: ") + text.toHtmlEscaped() );
+        this->AppendText( Time, "[" + Util::ColorText::Underline( User ) + "]" + Util::ColorText::Bold(" :: ") + text );
 }
 
 void HavocNamespace::UserInterface::Widgets::Chat::AppendFromInput()
@@ -89,7 +89,7 @@ void HavocNamespace::UserInterface::Widgets::Chat::AppendFromInput()
         Head.Time         = QTime::currentTime().toString("hh:mm:ss").toStdString();
         Head.User         = User;
         Body.SubEvent     = Util::Packager::Chat::NewMessage;
-        Body.Info[ User ] = text.toHtmlEscaped().toUtf8().toBase64().toStdString();
+        Body.Info[ User ] = text().toUtf8().toBase64().toStdString();
 
         Package.Head = Head;
         Package.Body = Body;


### PR DESCRIPTION
Remove ".tohtmlescaped" attributes. This does not introduce any vulnerabilities to the code, it only breaks HTML characters. (as seen below)

```
< displays as "&lt"
> displays as "&gt"
" displays as "&quot;"
& displays as "&amp;"
```

![image](https://user-images.githubusercontent.com/72148770/194153689-1e777987-9c19-4d15-93ae-8486f53d30a3.png)