### PR TITLE
remove broken Client/Install.sh

### DIFF
--- a/Client/Install.sh
+++ b/Client/Install.sh
@@ -1,9 +1,0 @@
-echo "[*] Install needed libraries and packages for the Havoc client..."
-
-sudo apt update
-sudo apt --yes install cmake make python3-dev qtbase5-dev libqt5websockets5-dev libspdlog-dev python3-dev libboost-all-dev g++ gcc
-
-make clean
-./Build.sh
-cmake --build Build
-echo "[*] Libs are installed and Client has been built."


### PR DESCRIPTION
Pretty trivial pull btw

the following commands are no longer valid in Install.sh and it itself is pretty redundant and does not comply with the wiki
```bash
./Build.sh
cmake --build Build
```

why make such a trivial pull?
needed to cleanup the Client/ directory as i was writing a TUI for the havoc client but had too put that on hold cuz exams start this monday

good day sirs 🗿