### PR TITLE
Crash due to connection exception

### DIFF
--- a/Teamserver/data/implants/Demon/Source/Core/Package.c
+++ b/Teamserver/data/implants/Demon/Source/Core/Package.c
@@ -181,7 +181,7 @@ BOOL PackageTransmit( PPACKAGE Package, PVOID* Response, PSIZE_T Size )
         if ( TransportSend( Package->Buffer, Package->Length, Response, Size ) )
             Success = TRUE;
 
-        PackageDestroy( Package );
+        //PackageDestroy( Package );
     }
     else
     {


### PR DESCRIPTION
Crash steps.
1. kill teamserver
2. execute demon.exe
3. soon daemon.exe process exits due to a crash.

PackageTransmit function executes again to line 168 (Package.c) with a memory error due to PackageDestroy free.
