### PR TITLE
Add support for user supplied certificates

### DIFF
--- a/Teamserver/pkg/handlers/handlers.go
+++ b/Teamserver/pkg/handlers/handlers.go
@@ -18,6 +18,8 @@ type (
         Uris         []string
         HostHeader   string
         Secure       bool
+        CertPath     string
+        KeyPath      string
 
         Proxy struct {
             Enabled  bool

--- a/Teamserver/pkg/handlers/http.go
+++ b/Teamserver/pkg/handlers/http.go
@@ -60,7 +60,12 @@ func (h *HTTP) generateCertFiles() bool {
 	h.TLS.CertPath = ListenerPath + "server.crt"
 	h.TLS.KeyPath = ListenerPath + "server.key"
 
-	h.TLS.Cert, h.TLS.Key, err = certs.HTTPSGenerateRSACertificate(h.Config.HostBind)
+	if h.Config.CertPath == "" || h.Config.KeyPath == "" {
+		h.TLS.Cert, h.TLS.Key, err = certs.HTTPSGenerateRSACertificate(h.Config.HostBind)
+	} else {
+		h.TLS.Cert, err = os.ReadFile(h.Config.CertPath)
+		h.TLS.Key, err = os.ReadFile(h.Config.KeyPath)
+	}
 
 	err = os.WriteFile(h.TLS.CertPath, h.TLS.Cert, 0644)
 	if err != nil {

--- a/Teamserver/pkg/profile/config.go
+++ b/Teamserver/pkg/profile/config.go
@@ -72,6 +72,8 @@ type ListenerHTTP struct {
 	Headers   []string `yaotl:"Headers,optional"`
 	Uris      []string `yaotl:"Uris,optional"`
 	Secure    bool     `yaotl:"Secure,optional"`
+	CertPath  string   `yaotl:"CertPath,optional"`
+	KeyPath   string   `yaotl:"KeyPath,optional"`
 
 	Response *ListenerHttpResponse `yaotl:"Response,block"`
 	Proxy    *ListenerHttpProxy    `yaotl:"Proxy,block"`

--- a/Teamserver/pkg/teamserver/teamserver.go
+++ b/Teamserver/pkg/teamserver/teamserver.go
@@ -179,6 +179,8 @@ func (t *Teamserver) Start() {
 				Headers:      listener.Headers,
 				Uris:         listener.Uris,
 				Secure:       listener.Secure,
+				CertPath:     listener.CertPath,
+				KeyPath:      listener.KeyPath,
 			}
 
 			if listener.Response != nil {


### PR DESCRIPTION
This pull request will add support for user supplied SSL certificates via the `CertPath` and `KeyPath` profile configuration options.

For example, here's how a profile using a custom Let's Encrypt certificate would look:
```
Listeners {
    Http {
        Name        = "HTTPS Listener"
        Host        = "10.0.0.10"
        Port        = 443
        Method      = "POST"
        Secure      = true
        UserAgent   = "Mozilla/5.0 (Windows NT 10.0; Trident/7.0; rv:11.0) like Gecko"
        Uris        = [
            "/helloworld"
        ]
        Response {
            Headers = [
                "Content-type: text/plain",
            ]
        }
        CertPath = "/etc/letsencrypt/certs/fullchain_domain.crt"
        KeyPath = "/etc/letsencrypt/keys/domain.key"
    }
}
```