### PR TITLE
Moving a.Pivots.Links between AgentAdd and AgentSendNotify

### DIFF
--- a/Teamserver/pkg/agent/demons.go
+++ b/Teamserver/pkg/agent/demons.go
@@ -3728,13 +3728,13 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 
 							} else {
 								DemonInfo = ParseResponse(AgentHdr.AgentID, AgentHdr.Data)
-								DemonInfo.Pivots.Parent = a
-
-								a.Pivots.Links = append(a.Pivots.Links, DemonInfo)
-
 								DemonInfo.Info.MagicValue = AgentHdr.MagicValue
 
 								teamserver.AgentAdd(DemonInfo)
+
+								DemonInfo.Pivots.Parent = a
+								a.Pivots.Links = append(a.Pivots.Links, DemonInfo)
+
 								teamserver.AgentSendNotify(DemonInfo)
 
 								go DemonInfo.BackgroundUpdateLastCallbackUI(teamserver)


### PR DESCRIPTION
# Issue 
When executing the pivot command the Havoc Teamserver would crash. To reproduce this run the following on the Client:

# Reproduce
run the following command in the Havoc Client:

`pivot connect <HOST> <SMB_PIPE>`

# What I changed
I fixed this by moving a.Pivots.Links between AgentAdd and AgentSendNotify