### PR TITLE
Adds PipeSend, PipeRead 

### DIFF
--- a/Teamserver/data/implants/Demon/Include/Core/TransportSmb.h
+++ b/Teamserver/data/implants/Demon/Include/Core/TransportSmb.h
@@ -3,6 +3,9 @@
 
 #include <Core/WinUtils.h>
 
+PipeSend(HANDLE pipeHandle, PBUFFER Send);
+PipeRead(HANDLE pipeHandle, PBUFFER Receive);
+
 #ifdef TRANSPORT_SMB
 
 /* Objects we allocated and need to free */

--- a/Teamserver/data/implants/Demon/Source/Core/Command.c
+++ b/Teamserver/data/implants/Demon/Source/Core/Command.c
@@ -9,6 +9,7 @@
 #include <Core/SleepObf.h>
 #include <Core/Download.h>
 #include <Core/Dotnet.h>
+#include <Core/TransportSmb.h>
 
 #include <Loader/CoffeeLdr.h>
 #include <Inject/Inject.h>
@@ -2385,7 +2386,10 @@ VOID CommandPivot( PPARSER Parser )
 
             if ( PivotData )
             {
-                if ( ! Instance.Win32.WriteFile( PivotData->Handle, Data, Size, &Size, NULL ) )
+                BUFFER Send = { 0 };
+                Send.Buffer = Data;
+                Send.Length = Size;
+                if (!PipeSend( PivotData->Handle, &Send))
                 {
                     PRINTF( "WriteFile: Failed[%d]\n", NtGetLastError() );
                     CALLBACK_GETLASTERROR

--- a/Teamserver/data/implants/Demon/Source/Core/Pivot.c
+++ b/Teamserver/data/implants/Demon/Source/Core/Pivot.c
@@ -1,11 +1,11 @@
 #include <Demon.h>
 
 #include <Common/Macros.h>
-
 #include <Core/Parser.h>
 #include <Core/MiniStd.h>
 #include <Core/Command.h>
 #include <Core/Package.h>
+#include <Core/TransportSmb.h>
 
 /* TODO: Change the way new pivots gets added.
  *
@@ -53,8 +53,11 @@ BOOL PivotAdd( BUFFER NamedPipe, PVOID* Output, PSIZE_T BytesSize )
 
                 *Output = Instance.Win32.LocalAlloc( LPTR, *BytesSize );
                 MemSet( *Output, 0, *BytesSize );
+                BUFFER Resp = { 0 };
+                Resp.Buffer = *Output;
+                Resp.Length = *BytesSize;
 
-                if ( Instance.Win32.ReadFile( Handle, *Output, *BytesSize, BytesSize, NULL ) )
+                if (PipeRead(Handle, &Resp))
                 {
                     PRINTF( "BytesSize Read => %d\n", *BytesSize );
                     break;


### PR DESCRIPTION
You can send a maximum of 65535 bytes on a pipe. Attempting to write more data, causes a WriteFile error, making upload large files impossible. These two new methods abstract this logic away and allow the rest of the program to send data like it usual.

This fixes the upload command on an SMB implant. This should also close #218.

However, Downloading big files via an SMB pivot is still buggy and this PR does not fix it yet. Maybe someone else can have a look at it.