### PR TITLE
refactor payload dialog

### DIFF
--- a/client/Source/UserInterface/Dialogs/Payload.cpp
+++ b/client/Source/UserInterface/Dialogs/Payload.cpp
@@ -143,7 +143,10 @@ auto Payload::retranslateUi() -> void
     {
         ComboListener->setDisabled( false );
         for ( auto& Listener : HavocX::Teamserver.Listeners )
-            ComboListener->addItem( Listener.Name.c_str() );
+        {
+            if ( Listener.Status.compare( "Offline" ) != 0 )
+                ComboListener->addItem( Listener.Name.c_str() );
+        }
     }
     else
     {
@@ -284,6 +287,8 @@ auto Payload::ReceivedImplantAndSave( QString FileName, QByteArray ImplantArray 
             messageBox.setStyleSheet( FileRead( ":/stylesheets/MessageBox" ) );
             messageBox.setMaximumSize( QSize(500, 500 ) );
             messageBox.exec();
+
+            PayloadDialog->done( 0 );
         }
     }
 }


### PR DESCRIPTION
I do this so often that small things become annoying 😛 
1) if a listener is offline, it is not offered to the user
2) when the payload was generated and the user clicks 'Ok', the dialog closes itself