### PR TITLE
payload dialog: remove 'ButtonClicked'

### DIFF
--- a/client/Include/UserInterface/Dialogs/Payload.hpp
+++ b/client/Include/UserInterface/Dialogs/Payload.hpp
@@ -21,7 +21,6 @@
 class Payload : public QDialog
 {
     bool            Closed = false;
-    bool            ButtonClicked = false;
 public:
     QDialog*        PayloadDialog;
 

--- a/client/Source/UserInterface/Dialogs/Payload.cpp
+++ b/client/Source/UserInterface/Dialogs/Payload.cpp
@@ -188,9 +188,6 @@ auto Payload::retranslateUi() -> void
 
 void Payload::buttonGenerate()
 {
-    if ( ButtonClicked )
-        return;
-
     if ( HavocX::Teamserver.Listeners.size() == 0 )
     {
         auto messageBox = QMessageBox(  );
@@ -220,7 +217,6 @@ void Payload::buttonGenerate()
     }
 
     ConsoleText->clear();
-    ButtonClicked = true;
 
     auto Config  = GetConfigAsJson().toJson().toStdString();
     auto Package = new Util::Packager::Package;
@@ -254,8 +250,6 @@ auto Payload::ReceivedImplantAndSave( QString FileName, QByteArray ImplantArray 
     auto FileDialog = QFileDialog();
     auto Filename   = QUrl();
     auto Style      = FileRead( ":/stylesheets/Dialogs/FileDialog" ).toStdString();
-
-    ButtonClicked = false;
 
     Style.erase( std::remove( Style.begin(), Style.end(), '\n' ), Style.end() );
 
@@ -362,7 +356,6 @@ auto Payload::CtxAgentPayloadChange( const QString& AgentType ) -> void
 auto Payload::Clear() -> void
 {
     Closed = true;
-    ButtonClicked = false;
 
     ComboAgentType->setCurrentIndex( 0 );
     ComboListener->setCurrentIndex( 0 );


### PR DESCRIPTION
If you modify Demons code and the compile fails, to re-compile you need to close the client and open it again.  
This can be time consuming while refactoring/fixing/adding code.  
Now, you can recompile as many times as you want without closing the client.  

This fixes https://github.com/HavocFramework/Havoc/issues/217