### PR TITLE
fix net users text error

### DIFF
--- a/teamserver/pkg/agent/demons.go
+++ b/teamserver/pkg/agent/demons.go
@@ -4533,11 +4533,11 @@ func (a *Agent) TaskDispatch(CommandID int, Parser *parser.Parser, teamserver Te
 
 				if Parser.CanIRead([]parser.ReadType{parser.ReadBytes}) {
 					logger.Debug(fmt.Sprintf("Agent: %x, Command: COMMAND_NET - DEMON_NET_COMMAND_USERS", AgentID))
-					var Target = Parser.ParseString()
+					var Target = Parser.ParseUTF16String()
 
 					for Parser.CanIRead([]parser.ReadType{parser.ReadBytes, parser.ReadInt32}) {
 						var (
-							User  = Parser.ParseString()
+							User  = Parser.ParseUTF16String()
 							Admin = Parser.ParseInt32()
 						)
 


### PR DESCRIPTION
The net users command returns wide bytes, so it needs to be decoded using utf16

