### PR TITLE
fix WCharStringToCharString function error

### DIFF
--- a/payloads/Demon/Source/Core/MiniStd.c
+++ b/payloads/Demon/Source/Core/MiniStd.c
@@ -126,15 +126,32 @@ INT MemCompare( PVOID s1, PVOID s2, INT len)
 
 SIZE_T WCharStringToCharString(PCHAR Destination, PWCHAR Source, SIZE_T MaximumAllowed)
 {
-    INT Length = MaximumAllowed;
-
-    while (--Length >= 0)
-    {
-        if (!(*Destination++ = *Source++))
-            return MaximumAllowed - Length - 1;
+    SIZE_T DestLen = 0;
+    for (SIZE_T i = 0; i < MaximumAllowed; i++) {
+        if (Source[i] <= 0x7F) {
+            Destination[DestLen++] = (char)Source[i];
+        }
+        else if (Source[i] <= 0x7FF) {
+            Destination[DestLen++] = (char)(0xC0 | (Source[i] >> 6));
+            Destination[DestLen++] = (char)(0x80 | (Source[i] & 0x3F));
+        }
+        else if (Source[i] <= 0xFFFF) {
+            Destination[DestLen++] = (char)(0xE0 | (Source[i] >> 12));
+            Destination[DestLen++] = (char)(0x80 | ((Source[i] >> 6) & 0x3F));
+            Destination[DestLen++] = (char)(0x80 | (Source[i] & 0x3F));
+        }
+        else {
+            Destination[DestLen++] = (char)(0xF0 | (Source[i] >> 18));
+            Destination[DestLen++] = (char)(0x80 | ((Source[i] >> 12) & 0x3F));
+            Destination[DestLen++] = (char)(0x80 | ((Source[i] >> 6) & 0x3F));
+            Destination[DestLen++] = (char)(0x80 | (Source[i] & 0x3F));
+        }
     }
 
-    return MaximumAllowed - Length;
+
+    Destination[DestLen] = '\0';
+
+    return DestLen;
 }
 
 SIZE_T CharStringToWCharString( PWCHAR Destination, PCHAR Source, SIZE_T MaximumAllowed )


### PR DESCRIPTION
When the parameter Source is unicode, such as Japanese, the conversion results in garbled text(I think it should be called toutf8 , not tochar ), And CharStringToWCharString function seems to have this problem too , but I haven't changed it yet


For example, net localgroup uses the WCharStringToCharString function, which can be tested using this command