### PR TITLE
pipes with more rng.

### DIFF
--- a/teamserver/pkg/agent/demons.go
+++ b/teamserver/pkg/agent/demons.go
@@ -577,11 +577,31 @@ func (a *Agent) TaskPrepare(Command int, Info any, Message *map[string]string, C
 
 	// TODO: make it more malleable/random values
 	case COMMAND_ASSEMBLY_INLINE_EXECUTE:
+		rand.Seed(time.Now().UnixNano())
+		const pipePrefix = "\\\\.\\pipe\\mojo."
+		const (
+			runeALen = 4
+			runeBLen = 4
+			runeCLen = 12
+			runeDLen = 7
+		)
+
+		generateRuneString := func(length int) string {
+			pipeRunes := []rune("0123456789")
+			runes := make([]rune, length)
+			for i := range runes {
+				runes[i] = pipeRunes[rand.Intn(len(pipeRunes))]
+			}
+			return string(runes)
+		}
+
+		finalPipe := pipePrefix + generateRuneString(runeALen) + "." + generateRuneString(runeBLen) + "." + generateRuneString(runeCLen) + generateRuneString(runeDLen)
+
 		var (
 			binaryDecoded, _ = base64.StdEncoding.DecodeString(Optional["Binary"].(string))
 			arguments        = common.EncodeUTF16(Optional["Arguments"].(string))
 			NetVersion       = common.EncodeUTF16("v4.0.30319")
-			PipePath         = common.EncodeUTF16("\\\\.\\pipe\\mojo." + strconv.Itoa(rand.Intn(9999)) + "." + strconv.Itoa(rand.Intn(9999)) + "." + strconv.Itoa(rand.Intn(999999999999)) + strconv.Itoa(rand.Intn(9999999)))
+			PipePath         = common.EncodeUTF16(finalPipe)
 			AppDomainName    = common.EncodeUTF16("DefaultDomain")
 		)
 


### PR DESCRIPTION
Re-open PR targeting `dev`.  Adds more RNG to inline assembly execution named pipes. Rather than rely on strictly intr(9999).