### PR TITLE
fixing null dereference and argument check

### DIFF
--- a/Client/Source/Havoc/Demon/ConsoleInput.cpp
+++ b/Client/Source/Havoc/Demon/ConsoleInput.cpp
@@ -1123,19 +1123,17 @@ auto DemonCommands::DispatchCommand( bool Send, QString TaskID, const QString& c
             }
             else if ( InputCommands[ 1 ].compare( "inline-execute" ) == 0 )
             {
-                auto File = InputCommands[ 2 ];
                 auto Args = QString();
 
                 // dotnet inline-execute assembly.exe (args)
-                if ( InputCommands.size() > 3 )
+                if ( InputCommands.size() < 3 )
                 {
-                    InputCommands[ 0 ] = "";
-                    InputCommands[ 1 ] = "";
-                    InputCommands[ 2 ] = "";
-
-                    Args = InputCommands.join( " " );
+		            CONSOLE_ERROR( "Not enough arguments" );
+		            return false;
                 }
-
+                
+                auto File = InputCommands[ 2 ];
+                
                 if ( ! QFile::exists( File ) )
                 {
                     CONSOLE_ERROR( "Couldn't find assembly file: " + File );


### PR DESCRIPTION
 fixed a null dereference issue in the third argument of the `dotnet` command specifically in the `inline-execute` subcommand, that could occur when no additional arguments were provided, Additionally, I added a check to ensure that the correct number of arguments is provided .

![Screenshot 2023-04-16 141029](https://user-images.githubusercontent.com/60795188/232321804-f47adcee-6f7a-402a-8090-107139bbbfdf.png)

![image](https://user-images.githubusercontent.com/60795188/232321750-1d300015-d677-441f-9819-43e8a8a677ce.png)
