### PR TITLE
fix wget command on teamserver Install script

### DIFF
--- a/teamserver/Install.sh
+++ b/teamserver/Install.sh
@@ -3,7 +3,7 @@
 if [ ! -d "dir/x86_64-w64-mingw32-cross" ]; then
 	sudo apt -qq --yes install golang-go nasm mingw-w64 wget >/dev/null 2>&1
 	if [ ! -f /tmp/mingw-musl.tgz ]; then
-		wget https://musl.cc/x86_64-w64-mingw32-cross.tgz -q -O /tmp/mingw-musl.tgz
+		wget https://musl.cc/x86_64-w64-mingw32-cross.tgz -q -o /tmp/mingw-musl.tgz
 	fi
 	
 	if [ ! -d "data" ]; then


### PR DESCRIPTION
Minor issue which was making install to fail, Install script was not working so i changed wget -O flag to -o and it worked fine. Looks like some versions of wget don't recognize -O