### PR TITLE
Packager.cpp make error fix

### DIFF
--- a/client/Source/Havoc/Packager.cpp
+++ b/client/Source/Havoc/Packager.cpp
@@ -307,7 +307,7 @@ bool Packager::DispatchListener( Util::Packager::PPackage Package )
 
                 for ( const auto& listener : HavocX::Teamserver.RegisteredListeners )
                 {
-                    if ( ListenerInfo.Protocol == listener[ "Name" ] )
+                    if ( ListenerInfo.Protocol == listener[ "Name" ].get<std::string>() )
                     {
                         found = true;
 


### PR DESCRIPTION
in my environment, line 310 occur error.
/opt/Havoc/client/Source/Havoc/Packager.cpp:310:48: error: no match for `operator==` (operand types are `std::string` {aka `std::__cxx11::basic_string<char>`} and `const nlohmann::json_abi_v3_11_2::basic_json<>::value_type` {aka `const nlohmann::json_abi_v3_11_2::basic_json<>`})

i changed that code and my error is fixed.