### PR TITLE
fix bug & opt optimization client text encoding

### DIFF
--- a/client/Include/global.hpp
+++ b/client/Include/global.hpp
@@ -25,6 +25,7 @@
 #include <QLineEdit>
 #include <QTextEdit>
 #include <QTableWidget>
+#include <QTextCodec>
 
 #include <string>
 #include <map>

--- a/client/Source/Main.cpp
+++ b/client/Source/Main.cpp
@@ -6,6 +6,8 @@ int main( int argc, char** argv )
 {
     auto Arguments = cmdline::parser();
     auto HavocApp  = QApplication( argc, argv );
+    QTextCodec* codec = QTextCodec::codecForName( "UTF-8" );
+    QTextCodec::setCodecForLocale( codec );
 
     spdlog::set_pattern( "[%T] [%^%l%$] %v" );
     spdlog::info( "Havoc Framework [Version: {}] [CodeName: {}]", HavocNamespace::Version, HavocNamespace::CodeName );

--- a/teamserver/cmd/server/dispatch.go
+++ b/teamserver/cmd/server/dispatch.go
@@ -178,12 +178,14 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 
 									var ClientID string
 									ClientID = ""
-									for _, client := range t.Clients {
+									t.Clients.Range(func(key, value any) bool {
+										client := value.(*Client)
 										if client.Username == pk.Head.User {
 											ClientID = client.ClientID
-											break
+											return false
 										}
-									}
+										return true
+									})
 
 									job, err = t.Agents.Agents[i].TaskPrepare(command, pk.Body.Info, Message, ClientID, t)
 									if err != nil {
@@ -406,68 +408,88 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 						if val, ok = pk.Body.Info["Proxy Type"].(string); ok {
 							Config.Proxy.Type = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy type not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 						}
 
 						if val, ok = pk.Body.Info["Proxy Host"].(string); ok {
 							Config.Proxy.Host = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy host not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 						}
 
 						if val, ok = pk.Body.Info["Proxy Port"].(string); ok {
 							Config.Proxy.Port = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy port not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 
 						if val, ok = pk.Body.Info["Proxy Username"].(string); ok {
 							Config.Proxy.Username = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy username not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 
 						if val, ok = pk.Body.Info["Proxy Password"].(string); ok {
 							Config.Proxy.Password = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy password not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 					}
@@ -478,14 +500,18 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 				}
 
 				if err := t.ListenerStart(handlers.LISTENER_HTTP, Config); err != nil {
-					for id, client := range t.Clients {
+					t.Clients.Range(func(key, value any) bool {
+						id := key.(string)
+						client := value.(*Client)
 						if client.Username == pk.Head.User {
 							err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), err))
 							if err != nil {
 								logger.Error("Failed to send Event: " + err.Error())
 							}
+							return false
 						}
-					}
+						return true
+					})
 				}
 
 				break
@@ -507,14 +533,18 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 				}
 
 				if err := t.ListenerStart(handlers.LISTENER_PIVOT_SMB, SmdConfig); err != nil {
-					for id, client := range t.Clients {
+					t.Clients.Range(func(key, value any) bool {
+						id := key.(string)
+						client := value.(*Client)
 						if client.Username == pk.Head.User {
 							err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), err))
 							if err != nil {
 								logger.Error("Failed to send Event: " + err.Error())
 							}
+							return false
 						}
-					}
+						return true
+					})
 				}
 
 				break
@@ -537,14 +567,18 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 				}
 
 				if err := t.ListenerStart(handlers.LISTENER_EXTERNAL, ExtConfig); err != nil {
-					for id, client := range t.Clients {
+					t.Clients.Range(func(key, value any) bool {
+						id := key.(string)
+						client := value.(*Client)
 						if client.Username == pk.Head.User {
 							err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), err))
 							if err != nil {
 								logger.Error("Failed to send Event: " + err.Error())
 							}
+							return false
 						}
-					}
+						return true
+					})
 				}
 
 				break
@@ -667,68 +701,88 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 						if val, ok = pk.Body.Info["Proxy Type"].(string); ok {
 							Config.Proxy.Type = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy type not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 						}
 
 						if val, ok = pk.Body.Info["Proxy Host"].(string); ok {
 							Config.Proxy.Host = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy host not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 						}
 
 						if val, ok = pk.Body.Info["Proxy Port"].(string); ok {
 							Config.Proxy.Port = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy port not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 
 						if val, ok = pk.Body.Info["Proxy Username"].(string); ok {
 							Config.Proxy.Username = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy username not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 
 						if val, ok = pk.Body.Info["Proxy Password"].(string); ok {
 							Config.Proxy.Password = val
 						} else {
-							for id, client := range t.Clients {
+							t.Clients.Range(func(key, value any) bool {
+								id := key.(string)
+								client := value.(*Client)
 								if client.Username == pk.Head.User {
 									err := t.SendEvent(id, events.Listener.ListenerError(pk.Head.User, pk.Body.Info["Name"].(string), errors.New("proxy password not specified")))
 									if err != nil {
 										logger.Error("Failed to send Event: " + err.Error())
 									}
+									return false
 								}
-							}
+								return true
+							})
 							return
 						}
 					}
@@ -766,11 +820,14 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 				ClientID       string
 			)
 
-			for _, client := range t.Clients {
-				if client.Username == pk.Head.User {
-					ClientID = client.ClientID
+			t.Clients.Range(func(key, value any) bool {
+				Client := value.(*Client)
+				if Client.Username == pk.Head.User {
+					ClientID = Client.ClientID
+					return false
 				}
-			}
+				return true
+			})
 
 			SendConsoleMsg = func(MsgType, Message string) {
 				err := t.SendEvent(ClientID, events.Gate.SendConsoleMessage(MsgType, Message))

--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -24,8 +24,8 @@ import (
 	"github.com/gorilla/websocket"
 	"golang.org/x/crypto/sha3"
 
-	"Havoc/pkg/common"
 	"Havoc/pkg/colors"
+	"Havoc/pkg/common"
 	"Havoc/pkg/events"
 	"Havoc/pkg/handlers"
 	"Havoc/pkg/logger"
@@ -93,14 +93,15 @@ func (t *Teamserver) Start() {
 			return
 		}
 
-		t.Clients[ClientID] = &Client{
-			Username:      "",
-			GlobalIP:      WebSocket.RemoteAddr().String(),
-			Connection:    WebSocket,
-			ClientVersion: "",
-			Packager:      packager.NewPackager(),
-			Authenticated: false,
-		}
+		t.Clients.Store(ClientID,
+			&Client{
+				Username:      "",
+				GlobalIP:      WebSocket.RemoteAddr().String(),
+				Connection:    WebSocket,
+				ClientVersion: "",
+				Packager:      packager.NewPackager(),
+				Authenticated: false,
+			})
 
 		// Handle connections in a new goroutine.
 		go t.handleRequest(ClientID)
@@ -160,7 +161,6 @@ func (t *Teamserver) Start() {
 	}(t.Flags.Server.Host, t.Flags.Server.Port)
 
 	t.WebHooks = webhook.NewWebHook()
-	t.Clients = make(map[string]*Client)
 	t.Listeners = []*Listener{}
 
 	TeamserverWs = "wss://" + t.Flags.Server.Host + ":" + t.Flags.Server.Port
@@ -493,22 +493,30 @@ func (t *Teamserver) Start() {
 }
 
 func (t *Teamserver) handleRequest(id string) {
-	_, NewClient, err := t.Clients[id].Connection.ReadMessage()
+	value, isok := t.Clients.Load(id)
+
+	if !isok {
+		return
+	}
+
+	client := value.(*Client)
+	_, NewClient, err := client.Connection.ReadMessage()
 
 	if err != nil {
 		if err != io.EOF {
 			logger.Error("Error reading 2:", err.Error())
 			if strings.Contains(err.Error(), "connection reset by peer") {
-				err := t.Clients[id].Connection.Close()
+				err := client.Connection.Close()
 				if err != nil {
 					logger.Error("Error while closing Client connection: " + err.Error())
 				}
 			}
 		}
+		t.Clients.Delete(id)
 		return
 	}
 
-	pk := t.Clients[id].Packager.CreatePackage(string(NewClient))
+	pk := client.Packager.CreatePackage(string(NewClient))
 
 	if t.Profile != nil {
 		var found = false
@@ -521,45 +529,45 @@ func (t *Teamserver) handleRequest(id string) {
 			err := t.SendEvent(id, events.UserDoNotExists())
 			if err != nil {
 				logger.Error("Error while sending package to " + colors.Red(id) + "")
-				return
 			}
 			t.RemoveClient(id)
+			return
 		}
 	}
 
-	for i := range t.Clients {
-		if t.Clients[i].Username == pk.Head.User {
+	isExist := false
+	t.Clients.Range(func(key, value any) bool {
+		if client.Username == pk.Head.User {
 			err := t.SendEvent(id, events.UserAlreadyExits())
 			if err != nil {
 				logger.Error("couldn't send event to client "+colors.Yellow(id)+":", err)
 			}
 			t.RemoveClient(id)
+			isExist = true
+			return false
 		}
+		return true
+	})
+	if isExist {
+		return
 	}
-
 	if !t.ClientAuthenticate(pk) {
-		if t.Clients[id] == nil {
-			return
-		}
-		logger.Error("Client [User: " + pk.Body.Info["User"].(string) + "] failed to Authenticate! (" + colors.Red(t.Clients[id].GlobalIP) + ")")
+		logger.Error("Client [User: " + pk.Body.Info["User"].(string) + "] failed to Authenticate! (" + colors.Red(client.GlobalIP) + ")")
 		err := t.SendEvent(id, events.Authenticated(false))
 		if err != nil {
 			logger.Error("client (" + colors.Red(id) + ") error while sending authenticate message: " + colors.Red(err))
 		}
-		err = t.Clients[id].Connection.Close()
+		err = client.Connection.Close()
 		if err != nil {
 			logger.Error("Failed to close client (" + id + ") socket")
 		}
 		return
 	} else {
-		if t.Clients[id] == nil {
-			return
-		}
 
 		logger.Good("User <" + colors.Blue(pk.Body.Info["User"].(string)) + "> " + colors.Green("Authenticated"))
 
-		t.Clients[id].Authenticated = true
-		t.Clients[id].ClientID = id
+		client.Authenticated = true
+		client.ClientID = id
 
 		err := t.SendEvent(id, events.Authenticated(true))
 		if err != nil {
@@ -567,21 +575,26 @@ func (t *Teamserver) handleRequest(id string) {
 		}
 	}
 
-	t.Clients[id].Username = pk.Body.Info["User"].(string)
-	packageNewUser := events.ChatLog.NewUserConnected(t.Clients[id].Username)
+	client.Username = pk.Body.Info["User"].(string)
+	packageNewUser := events.ChatLog.NewUserConnected(client.Username)
 	t.EventAppend(packageNewUser)
 	t.EventBroadcast(id, packageNewUser)
 
 	t.SendAllPackagesToNewClient(id)
 
 	for {
-		_, EventPackage, err := t.Clients[id].Connection.ReadMessage()
+		value, isok := t.Clients.Load(id)
+		if !isok {
+			return
+		}
+		client = value.(*Client)
+		_, EventPackage, err := client.Connection.ReadMessage()
 
 		if err != nil {
 			if websocket.IsCloseError(err, websocket.CloseAbnormalClosure) {
-				logger.Warn("User <" + colors.Blue(t.Clients[id].Username) + "> " + colors.Red("Disconnected"))
+				logger.Warn("User <" + colors.Blue(client.Username) + "> " + colors.Red("Disconnected"))
 
-				t.EventAppend(events.ChatLog.UserDisconnected(t.Clients[id].Username))
+				t.EventAppend(events.ChatLog.UserDisconnected(client.Username))
 				t.RemoveClient(id)
 
 				return
@@ -589,18 +602,18 @@ func (t *Teamserver) handleRequest(id string) {
 				logger.Error("Error reading :", err.Error())
 			}
 
-			err := t.Clients[id].Connection.Close()
+			err := client.Connection.Close()
 			if err != nil {
 				logger.Error("Socket Error:", err.Error())
 			}
 
-			t.EventAppend(events.ChatLog.UserDisconnected(t.Clients[id].Username))
+			t.EventAppend(events.ChatLog.UserDisconnected(client.Username))
 			t.RemoveClient(id)
 
 			return
 		}
 
-		pk := t.Clients[id].Packager.CreatePackage(string(EventPackage))
+		pk := client.Packager.CreatePackage(string(EventPackage))
 		pk.Head.Time = time.Now().Format("02/01/2006 15:04:05")
 
 		t.EventAppend(pk)
@@ -679,14 +692,16 @@ func (t *Teamserver) EventBroadcast(ExceptClient string, pk packager.Package) {
 		return
 	}
 
-	for ClientID := range t.Clients {
+	t.Clients.Range(func(key, value any) bool {
+		ClientID := key.(string)
 		if ExceptClient != ClientID {
 			err := t.SendEvent(ClientID, pk)
 			if err != nil && !strings.Contains(err.Error(), "use of closed network connection") {
 				logger.Error("SendEvent error: ", colors.Red(err))
 			}
 		}
-	}
+		return true
+	})
 }
 
 func (t *Teamserver) EventNewDemon(DemonAgent *agent.Agent) packager.Package {
@@ -732,18 +747,19 @@ func (t *Teamserver) SendEvent(id string, pk packager.Package) error {
 		return err
 	}
 
-	if t.Clients[id] != nil {
+	value, isOk := t.Clients.Load(id)
+	if isOk {
+		client := value.(*Client)
+		client.Mutex.Lock()
 
-		t.Clients[id].Mutex.Lock()
-
-		err = t.Clients[id].Connection.WriteMessage(websocket.BinaryMessage, buffer.Bytes())
+		err = client.Connection.WriteMessage(websocket.BinaryMessage, buffer.Bytes())
 		if err != nil {
 			// TODO: comment this line out as it seems to crash the server
 			//t.Clients[id].Mutex.Unlock()
 			return err
 		}
 
-		t.Clients[id].Mutex.Unlock()
+		client.Mutex.Unlock()
 
 	} else {
 		return errors.New(fmt.Sprintf("client (%v) doesn't exist anymore", colors.Red(id)))
@@ -753,10 +769,14 @@ func (t *Teamserver) SendEvent(id string, pk packager.Package) error {
 }
 
 func (t *Teamserver) RemoveClient(ClientID string) {
-	if _, ok := t.Clients[ClientID]; ok {
+
+	value, isOk := t.Clients.Load(ClientID)
+
+	if isOk {
+		client := value.(*Client)
 		var (
-			userDisconnected = t.Clients[ClientID].Username
-			Authenticated    = t.Clients[ClientID].Authenticated
+			userDisconnected = client.Username
+			Authenticated    = client.Authenticated
 		)
 
 		if Authenticated {
@@ -768,7 +788,7 @@ func (t *Teamserver) RemoveClient(ClientID string) {
 			}
 		}
 
-		delete(t.Clients, ClientID)
+		t.Clients.Delete(ClientID)
 	}
 }
 

--- a/teamserver/cmd/server/types.go
+++ b/teamserver/cmd/server/types.go
@@ -73,7 +73,7 @@ type Endpoint struct {
 type Teamserver struct {
 	Flags      TeamserverFlags
 	Profile    *profile.Profile
-	Clients    map[string]*Client
+	Clients    sync.Map // map[string]*Client
 	Users      []Users
 	EventsList []packager.Package
 	Service    *service.Service


### PR DESCRIPTION
1.fix map race bug
  fatal error: concurrent map iteration and map write                                                                                                                                                           
  goroutine 19 [running]:                                                                                                                                                                                       runtime.throw({0xd5b1be?, 0xc00027e150?})
          /usr/lib/go-1.18/src/runtime/panic.go:992 +0x71 fp=0xc000287be0 sp=0xc000287bb0 pc=0x43caf1
  runtime.mapiternext(0xd55092?)
          /usr/lib/go-1.18/src/runtime/map.go:871 +0x4eb fp=0xc000287c50 sp=0xc000287be0 pc=0x41866b
  Havoc/cmd/server.(*Teamserver).EventBroadcast(0xc000328640, {0x0, 0x0}, {{0x10, {0x0, 0x0}, {0xc000316060, 0x13}, {0x0, 0x0}}, ...})
          /mnt/c/Havoc/teamserver/cmd/server/teamserver.go:682 +0xaa fp=0xc000287d60 sp=0xc000287c50 pc=0xb1288a
  Havoc/cmd.glob..func2.1({0xc000042310?, 0xc0000422a0?})
          /mnt/c/Havoc/teamserver/cmd/server.go:50 +0x170 fp=0xc000287e68 sp=0xc000287d60 pc=0xb16570
  Havoc/pkg/logr.Logr.ServerStdOutInit.func1()

2.opt client text encoding
