### PR TITLE
Fixed missing import causing builds to fail

### DIFF
--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -30,6 +30,7 @@ import (
 	"Havoc/pkg/logger"
 	"Havoc/pkg/packager"
 	"Havoc/pkg/profile"
+	"Havoc/pkg/service"
 	"Havoc/pkg/utils"
 )
 

--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -193,7 +193,7 @@ func (t *Teamserver) Start() {
 
     logger.Warn("Service api has been disabled for this version.")
 
-    /*
+    // 3rd Party Agent Support Enabled
 		t.Service = service.NewService(t.Server.Engine)
 		t.Service.Teamserver = t
 		t.Service.Data.ServerAgents = &t.Agents
@@ -204,7 +204,7 @@ func (t *Teamserver) Start() {
 			logger.Info(fmt.Sprintf("%v starting service handle on %v", "["+colors.BoldWhite("SERVICE")+"]", colors.BlueUnderline(TeamserverWs+"/"+t.Service.Config.Endpoint)))
 		} else {
 			logger.Error("Teamserver service error: Endpoint not specified")
-		}*/
+		}
 	}
 
 	/* now load up our db or start a new one if none exist */

--- a/teamserver/pkg/agent/agent.go
+++ b/teamserver/pkg/agent/agent.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"reflect" // <-- Added, 0xtriboulet
 
 	"Havoc/pkg/common"
 	"Havoc/pkg/common/crypt"
@@ -274,7 +275,22 @@ func RegisterInfoToInstance(Header Header, RegisterInfo map[string]any) *Agent {
 	if val, ok := RegisterInfo["OS Arch"]; ok {
 		agent.Info.OSArch = val.(string)
 	}
-
+	if val, ok := RegisterInfo["SleepDelay"]; ok { // 0xtriboulet
+		switch v := val.(type) {
+		case float64:
+			agent.Info.SleepDelay = int(v)
+		case string:
+			agent.Info.SleepDelay, err = strconv.Atoi(v)
+			if err != nil {
+				logger.DebugError("Couldn't parse SleepDelay integer from string: " + err.Error())
+				agent.Info.SleepDelay = 0
+			}
+		default:
+			// handle unexpected type
+			logger.DebugError("Unexpected type for SleepDelay: " + reflect.TypeOf(v).String())
+			agent.Info.SleepDelay = 0
+		}
+	}
 	agent.Info.FirstCallIn = time.Now().Format("02/01/2006 15:04:05")
 	agent.Info.LastCallIn = time.Now().Format("02-01-2006 15:04:05")
 	agent.BackgroundCheck = false


### PR DESCRIPTION
Love the framework and would just like to chime in here with a simple PR fix for #381. 

9a3307d uncommented the block of code for third-party agent support but forgot to include the import statement for the `service` Go module, causing `make ts-build` to fail.

