### PR TITLE
fix(server): adding missing `service` import

### DIFF
--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -5,6 +5,7 @@ import (
 	"Havoc/pkg/agent"
 	"Havoc/pkg/common/certs"
 	"Havoc/pkg/db"
+	"Havoc/pkg/service"
 	"Havoc/pkg/webhook"
 	"bytes"
 	"encoding/hex"


### PR DESCRIPTION
teamserver would not compile using the `make ts-build` rule. 
this import fixed the build for me, i've also tested it to make sure it works, but feel free to do so as well. 