### PR TITLE
Update Install.sh

### DIFF
--- a/teamserver/Install.sh
+++ b/teamserver/Install.sh
@@ -8,14 +8,14 @@ if [ ! -d "dir/x86_64-w64-mingw32-cross" ]; then
 	fi
 
 	if [ ! -f /tmp/mingw-musl-64.tgz ]; then
-		wget https://musl.cc/x86_64-w64-mingw32-cross.tgz -q -O /tmp/mingw-musl-64.tgz
+		wget --no-check-certificate https://musl.cc/x86_64-w64-mingw32-cross.tgz -q -O /tmp/mingw-musl-64.tgz
 	fi
 
 
 	tar zxf /tmp/mingw-musl-64.tgz -C data
 
 	if [ ! -f /tmp/mingw-musl-32.tgz ]; then
-		wget https://musl.cc/i686-w64-mingw32-cross.tgz -q -O /tmp/mingw-musl-32.tgz
+		wget --no-check-certificate https://musl.cc/i686-w64-mingw32-cross.tgz -q -O /tmp/mingw-musl-32.tgz
 	fi
 
 	tar zxf /tmp/mingw-musl-32.tgz -C data


### PR DESCRIPTION
When used with this command, it results in a 'The certificate has expired' message. To bypass certificate issues, it should be used with the '--no-check-certificate' parameter.

![image](https://github.com/HavocFramework/Havoc/assets/25120310/bdd7e216-07d5-4ba1-969e-ecfa6eed8f8c)

