### PR TITLE
Bug/update dockerfiles

### DIFF
--- a/client/Client-Dockerfile
+++ b/client/Client-Dockerfile
@@ -22,7 +22,7 @@
 #		`cd /go/Build/Bin/ && ./Havoc`
 #	You should now see the Havoc teamserver client running in a window!
 #
-#   	Install dependencies for running client locally 
+#   	Install dependencies for running client locally
 # 		'sudo apt-get update && sudo apt-get install -y git build-essential apt-utils cmake libfontconfig1 libglu1-mesa-dev libgtest-dev libspdlog-dev libboost-all-dev mesa-common-dev qtbase5-dev qtchooser qt5-qmake qtbase5-dev-tools libqt5websockets5 libqt5websockets5-dev qtdeclarative5-dev'
 #
 # Extras
@@ -32,7 +32,7 @@
 # 	Enter Container:
 #		'docker run exec -it <containerID> bash'
 # ------------------------------------------------------------------------------
-ARG GO_VERSION="1.19.1" 
+ARG GO_VERSION="1.19.1"
 FROM golang:${GO_VERSION}
 #
 # Set ENVs
@@ -48,7 +48,7 @@ RUN ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone
 # Manual cmake install
 RUN apt-get update && apt-get -y install wget
 #
-# Install dependencies                                            
+# Install dependencies
 RUN apt-get update && apt-get install -y \
     git \
     build-essential \
@@ -81,8 +81,28 @@ RUN apt-get update && apt-get install -y \
 RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh -O cmake.sh
 RUN sh cmake.sh --prefix=/usr/local/ --exclude-subdir
 #
-# Install Python3.10
-RUN apt install -y python3.10-dev libpython3.10 libpython3.10-dev python3.10 build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev
+# Install Python3.10 from Source
+RUN apt-get install -y \
+    build-essential \
+    zlib1g-dev \
+    libncurses5-dev \
+    libgdbm-dev \
+    libnss3-dev \
+    libssl-dev \
+    libreadline-dev \
+    libffi-dev \
+    libsqlite3-dev \
+    wget \
+    libbz2-dev
+
+RUN cd /tmp/ \
+    && wget https://www.python.org/ftp/python/3.10.13/Python-3.10.13.tgz \
+    && tar -xf Python-3.10.*.tgz \
+    && cd Python-3.10.*/ \
+    && ./configure --prefix=/usr/local --enable-optimizations --enable-shared LDFLAGS="-Wl,-rpath /usr/local/lib" \
+    && make -j $(nproc) \
+    && sudo make altinstall
+
 #
 # Copy over the client
 #COPY . Build/

--- a/teamserver/Teamserver-Dockerfile
+++ b/teamserver/Teamserver-Dockerfile
@@ -43,6 +43,7 @@ RUN apt update \
 	python3-pip \
 	rpm \
 	sudo \
+	libcap2-bin \
 	upx-ucl \
 	&& pip install --upgrade jsonschema
 #
@@ -53,8 +54,8 @@ RUN apt update \
 # Pull the repo from Github
 RUN git clone https://github.com/HavocFramework/Havoc
 #
-# Build the cloned repos copy of the Teamserver-Client  
-RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && make
+# Build the cloned repos copy of the Teamserver-Client
+RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && cd .. && make ts-build
 #
 # ------------------------------------------------------------------------------#
 # original @author      Nicola Asuni <info@tecnick.com>


### PR DESCRIPTION
## Client-Dockerfile Errors 
Apparently python3.10 is no longer available in golang:1.19.1

```bash
docker build -t havoc-client -f Client-Dockerfile .
[+] Building 254.1s (12/16)                                                                                                                                                                                                                                                                                        docker:desktop-linux
 => [internal] load .dockerignore                                                                                                                                                                                                                                                                                                  0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                                                                                    0.0s
 => [internal] load build definition from Client-Dockerfile                                                                                                                                                                                                                                                                        0.0s
 => => transferring dockerfile: 3.55kB                                                                                                                                                                                                                                                                                             0.0s
 => [internal] load metadata for docker.io/library/golang:1.19.1                                                                                                                                                                                                                                                                   2.3s
 => [ 1/13] FROM docker.io/library/golang:1.19.1@sha256:2d17ffd12a2cdb25d4a633ad25f8dc29608ed84f31b3b983427d825280427095                                                                                                                                                                                                          37.9s
 => => resolve docker.io/library/golang:1.19.1@sha256:2d17ffd12a2cdb25d4a633ad25f8dc29608ed84f31b3b983427d825280427095                                                                                                                                                                                                             0.0s
 => => sha256:122f3484f844467ebe0674cf57272e61981770eb0bc7d316d1f0be281a88229f 1.80kB / 1.80kB                                                                                                                                                                                                                                     0.0s
 => => sha256:4f7c78c9b46f6f45ba171e6031b4a8581536b2c215847d76cd42e5a7267a49ac 7.10kB / 7.10kB                                                                                                                                                                                                                                     0.0s
 => => sha256:326f452ade5c33097eba4ba88a24bd77a93a3d994d4dc39b936482655e664857 5.16MB / 5.16MB                                                                                                                                                                                                                                     0.5s
 => => sha256:a42821cd14fb31c4aa253203e7f8e34fc3b15d69ce370f1223fbbe4252a64202 10.88MB / 10.88MB                                                                                                                                                                                                                                   1.0s
 => => sha256:2d17ffd12a2cdb25d4a633ad25f8dc29608ed84f31b3b983427d825280427095 2.36kB / 2.36kB                                                                                                                                                                                                                                     0.0s
 => => sha256:23858da423a6737f0467fab0014e5b53009ea7405d575636af0c3f100bbb2f10 55.03MB / 55.03MB                                                                                                                                                                                                                                  15.1s
 => => sha256:8471b75885efc7790a16be5328e3b368567b76a60fc3feabd6869c15e175ee05 54.58MB / 54.58MB                                                                                                                                                                                                                                   4.6s
 => => sha256:b7aa120dd02d9fa75bb50861103f7837514028ea6f06e3e821b8c47c2c10d386 85.96MB / 85.96MB                                                                                                                                                                                                                                  10.2s
 => => sha256:292167c9d1ff24956858651ef9906e9a987b65f7362854e13c28b98d9ae4e09f 148.82MB / 148.82MB                                                                                                                                                                                                                                15.3s
 => => sha256:8709771bd9da550643f5f4e3b49e92bb3f90543507ff36b5a998dd461fb8dd28 157B / 157B                                                                                                                                                                                                                                        10.8s
 => => extracting sha256:23858da423a6737f0467fab0014e5b53009ea7405d575636af0c3f100bbb2f10                                                                                                                                                                                                                                          3.8s
 => => extracting sha256:326f452ade5c33097eba4ba88a24bd77a93a3d994d4dc39b936482655e664857                                                                                                                                                                                                                                          0.4s
 => => extracting sha256:a42821cd14fb31c4aa253203e7f8e34fc3b15d69ce370f1223fbbe4252a64202                                                                                                                                                                                                                                          0.3s
 => => extracting sha256:8471b75885efc7790a16be5328e3b368567b76a60fc3feabd6869c15e175ee05                                                                                                                                                                                                                                          3.9s
 => => extracting sha256:b7aa120dd02d9fa75bb50861103f7837514028ea6f06e3e821b8c47c2c10d386                                                                                                                                                                                                                                          3.6s
 => => extracting sha256:292167c9d1ff24956858651ef9906e9a987b65f7362854e13c28b98d9ae4e09f                                                                                                                                                                                                                                          9.8s
 => => extracting sha256:8709771bd9da550643f5f4e3b49e92bb3f90543507ff36b5a998dd461fb8dd28                                                                                                                                                                                                                                          0.0s
 => [ 2/13] RUN echo 'deb http://ftp.de.debian.org/debian bookworm main' >> /etc/apt/sources.list                                                                                                                                                                                                                                  0.6s
 => [ 3/13] RUN ln -snf /usr/share/zoneinfo/Europe/Kiev /etc/localtime && echo Europe/Kiev > /etc/timezone                                                                                                                                                                                                                         0.2s
 => [ 4/13] RUN apt-get update && apt-get -y install wget                                                                                                                                                                                                                                                                         16.3s
 => [ 5/13] RUN apt-get update && apt-get install -y     git     build-essential     apt-utils     cmake     libfontconfig1     libglu1-mesa-dev     libgtest-dev     libspdlog-dev     libboost-all-dev     mesa-common-dev      mingw-w64     nasm     sudo     python3     python3-all-dev     python3-pip                    155.2s
 => [ 6/13] RUN apt-get update && apt-get install -y     qtbase5-dev     qtchooser     qt5-qmake     qtbase5-dev-tools     libqt5websockets5     libqt5websockets5-dev     qtdeclarative5-dev                                                                                                                                     33.7s 
 => [ 7/13] RUN wget https://github.com/Kitware/CMake/releases/download/v3.24.1/cmake-3.24.1-Linux-x86_64.sh -O cmake.sh                                                                                                                                                                                                           4.5s 
 => [ 8/13] RUN sh cmake.sh --prefix=/usr/local/ --exclude-subdir                                                                                                                                                                                                                                                                  1.6s 
 => ERROR [ 9/13] RUN apt install -y python3.10-dev libpython3.10 libpython3.10-dev python3.10 build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev                                                                                             1.7s 
------                                                                                                                                                                                                                                                                                                                                  
 > [ 9/13] RUN apt install -y python3.10-dev libpython3.10 libpython3.10-dev python3.10 build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev:
0.256 
0.256 WARNING: apt does not have a stable CLI interface. Use with caution in scripts.
0.256 
0.264 Reading package lists...
1.382 Building dependency tree...
1.612 Reading state information...
1.683 E: Unable to locate package python3.10-dev
1.683 E: Couldn't find any package by glob 'python3.10-dev'
1.683 E: Unable to locate package libpython3.10
1.683 E: Couldn't find any package by glob 'libpython3.10'
1.683 E: Unable to locate package libpython3.10-dev
1.683 E: Couldn't find any package by glob 'libpython3.10-dev'
1.683 E: Unable to locate package python3.10
1.683 E: Couldn't find any package by glob 'python3.10'
------
Client-Dockerfile:85
--------------------
  83 |     #
  84 |     # Install Python3.10
  85 | >>> RUN apt install -y python3.10-dev libpython3.10 libpython3.10-dev python3.10 build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev
  86 |     #
  87 |     # Copy over the client
--------------------
ERROR: failed to solve: process "/bin/sh -c apt install -y python3.10-dev libpython3.10 libpython3.10-dev python3.10 build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget libbz2-dev" did not complete successfully: exit code: 100
```

## Teamserver-Dockerfile Error 1
No makefile exists in the teamserver directory

```bash
sudo docker build -t havoc-ts -f Teamserver-Dockerfile .
[+] Building 170.2s (7/7) FINISHED                                                                                                                                                                                           docker:default
 => [internal] load .dockerignore                                                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                                                        0.0s
 => [internal] load build definition from Teamserver-Dockerfile                                                                                                                                                                        0.0s
 => => transferring dockerfile: 2.03kB                                                                                                                                                                                                 0.0s
 => [internal] load metadata for docker.io/library/golang:1.19.1                                                                                                                                                                       0.4s
 => CACHED [1/4] FROM docker.io/library/golang:1.19.1@sha256:2d17ffd12a2cdb25d4a633ad25f8dc29608ed84f31b3b983427d825280427095                                                                                                          0.0s 
 => [2/4] RUN apt update  && apt -y install  alien  debhelper  devscripts  golang-go  nasm  mingw-w64  dh-golang  dh-make  fakeroot  pkg-config  python3-all-dev  python3-pip  rpm  sudo  upx-ucl  && pip install --upgrade jsonsch  112.0s 
 => [3/4] RUN git clone https://github.com/HavocFramework/Havoc                                                                                                                                                                        3.0s 
 => ERROR [4/4] RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && make                                                                                                                                             54.7s 
------                                                                                                                                                                                                                                      
 > [4/4] RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && make:                                                                                                                                                         
47.65 make: *** No targets specified and no makefile found.  Stop.                                                                                                                                                                          
------                                                                                                                                                                                                                                      
Teamserver-Dockerfile:57                                                                                                                                                                                                                    
--------------------                                                                                                                                                                                                                        
  55 |     #                                                                                                                                                                                                                                
  56 |     # Build the cloned repos copy of the Teamserver-Client                                                                                                                                                                           
  57 | >>> RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && make
  58 |     #
  59 |     # ------------------------------------------------------------------------------#
--------------------
ERROR: failed to solve: process "/bin/sh -c cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && make" did not complete successfully: exit code: 2
```


## Teamserver-Dockerfile Error 2 
Upon fixing the make directory, it was discovered that apparently `setcap` no longer exists in the `golang:1.19.1` image

```bash
docker build -t havoc-ts -f Teamserver-Dockerfile .                                                                                                                                                                                
[+] Building 112.9s (7/7) FINISHED                                                                                                                                                                                           docker:default
 => [internal] load build definition from Teamserver-Dockerfile                                                                                                                                                                        0.0s
 => => transferring dockerfile: 2.05kB                                                                                                                                                                                                 0.0s 
 => [internal] load .dockerignore                                                                                                                                                                                                      0.0s 
 => => transferring context: 2B                                                                                                                                                                                                        0.0s 
 => [internal] load metadata for docker.io/library/golang:1.19.1                                                                                                                                                                       0.1s 
 => [1/4] FROM docker.io/library/golang:1.19.1@sha256:2d17ffd12a2cdb25d4a633ad25f8dc29608ed84f31b3b983427d825280427095                                                                                                                 0.0s
 => CACHED [2/4] RUN apt update  && apt -y install  alien  debhelper  devscripts  golang-go  nasm  mingw-w64  dh-golang  dh-make  fakeroot  pkg-config  python3-all-dev  python3-pip  rpm  sudo  upx-ucl  && pip install --upgrade js  0.0s 
 => CACHED [3/4] RUN git clone https://github.com/HavocFramework/Havoc                                                                                                                                                                 0.0s 
 => ERROR [4/4] RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && cd .. && make ts-build                                                                                                                          112.7s 
------                                                                                                                                                                                                                                      
 > [4/4] RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && cd .. && make ts-build:                                                                                                                                       
40.60 [*] building teamserver                                                                                                                                                                                                               
52.17 go: downloading github.com/spf13/cobra v1.2.1                                                                                                                                                                                         
52.20 go: downloading github.com/fatih/color v1.12.0                                                                                                                                                                                        
52.31 go: downloading github.com/fatih/structs v1.1.0                                                                                                                                                                                       
52.32 go: downloading github.com/gin-gonic/gin v1.7.7
52.33 go: downloading github.com/gorilla/websocket v1.5.0
52.33 go: downloading golang.org/x/crypto v0.0.0-20220314234659-1baeb1ce4c0b
52.58 go: downloading github.com/mattn/go-colorable v0.1.8
52.59 go: downloading github.com/mattn/go-isatty v0.0.13
52.67 go: downloading github.com/spf13/pflag v1.0.5
52.70 go: downloading github.com/olekukonko/tablewriter v0.0.5
52.70 go: downloading golang.org/x/image v0.5.0
52.70 go: downloading golang.org/x/text v0.7.0
52.78 go: downloading github.com/mattn/go-sqlite3 v1.14.16
52.92 go: downloading github.com/gin-contrib/sse v0.1.0
53.09 go: downloading golang.org/x/sys v0.5.0
53.28 go: downloading github.com/mattn/go-runewidth v0.0.9
53.46 go: downloading github.com/go-playground/validator/v10 v10.4.1
53.46 go: downloading github.com/golang/protobuf v1.5.2
53.50 go: downloading github.com/ugorji/go/codec v1.1.7
53.51 go: downloading gopkg.in/yaml.v2 v2.4.0
53.57 go: downloading github.com/zclconf/go-cty v1.9.0
53.75 go: downloading github.com/agext/levenshtein v1.2.3
53.76 go: downloading github.com/apparentlymart/go-textseg/v13 v13.0.0
53.77 go: downloading github.com/mitchellh/go-wordwrap v1.0.1
53.78 go: downloading google.golang.org/protobuf v1.26.0
54.06 go: downloading github.com/go-playground/universal-translator v0.17.0
54.06 go: downloading github.com/leodido/go-urn v1.2.0
54.08 go: downloading github.com/google/go-cmp v0.5.6
54.12 go: downloading github.com/go-playground/locales v0.13.0
112.4 sudo: setcap: command not found
112.4 make: *** [makefile:13: ts-build] Error 1
------
Teamserver-Dockerfile:57
--------------------
  55 |     #
  56 |     # Build the cloned repos copy of the Teamserver-Client  
  57 | >>> RUN cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && cd .. && make ts-build
  58 |     #
  59 |     # ------------------------------------------------------------------------------#
--------------------
ERROR: failed to solve: process "/bin/sh -c cd Havoc/teamserver/ && chmod +x ./Install.sh && ./Install.sh && cd .. && make ts-build" did not complete successfully: exit code: 2
```