### PR TITLE
Update Main.cpp to fix font problem in kali + other distros

### DIFF
--- a/client/Source/Main.cpp
+++ b/client/Source/Main.cpp
@@ -1,42 +1,45 @@
 #include <global.hpp>
 #include <Havoc/Havoc.hpp>
 #include <Havoc/CmdLine.hpp>
+#include <QTimer>  
 
-int main( int argc, char** argv )
+int main(int argc, char** argv)
 {
     auto Arguments = cmdline::parser();
-    auto HavocApp  = QApplication( argc, argv );
-    QTextCodec* codec = QTextCodec::codecForName( "UTF-8" );
-    QTextCodec::setCodecForLocale( codec );
+    auto HavocApp = QApplication(argc, argv);
+    QTextCodec* codec = QTextCodec::codecForName("UTF-8");
+    QTextCodec::setCodecForLocale(codec);
 
-    spdlog::set_pattern( "[%T] [%^%l%$] %v" );
-    spdlog::info( "Havoc Framework [Version: {}] [CodeName: {}]", HavocNamespace::Version, HavocNamespace::CodeName );
+    spdlog::set_pattern("[%T] [%^%l%$] %v");
+    spdlog::info("Havoc Framework [Version: {}] [CodeName: {}]", HavocNamespace::Version, HavocNamespace::CodeName);
 
-    Arguments.add( "debug", '\0', "debug mode" );
-    Arguments.parse_check( argc, argv );
+    Arguments.add("debug", '\0', "debug mode");
+    Arguments.parse_check(argc, argv);
 
-    if ( Arguments.exist( "debug" ) )
+    if (Arguments.exist("debug"))
     {
-        spdlog::set_level( spdlog::level::debug );
-        spdlog::debug( "Debug mode enabled" );
+        spdlog::set_level(spdlog::level::debug);
+        spdlog::debug("Debug mode enabled");
         HavocX::DebugMode = true;
     }
 
-    auto FontID = QFontDatabase::addApplicationFont( ":/icons/Monaco" );
-    auto Family = QFontDatabase::applicationFontFamilies( FontID ).at( 0 );
-    auto Monaco = QFont( Family );
+    auto Monaco = QFont("Monospace", 10);  
+    QApplication::setFont(Monaco);
 
-    Monaco.setPointSize( 9 );
-    QApplication::setFont( Monaco );
+    auto setFontAgain = []() {
+        auto Monaco = QFont("Monospace", 10);  
+        QApplication::setFont(Monaco);
+    };
+    QTimer::singleShot(10, setFontAgain);
 
-    QGuiApplication::setWindowIcon( QIcon( ":/Havoc.ico" ) );
+    QGuiApplication::setWindowIcon(QIcon(":/Havoc.ico"));
 
-    HavocNamespace::HavocApplication = new HavocNamespace::HavocSpace::Havoc( new QMainWindow );
-    HavocNamespace::HavocApplication->Init( argc, argv );
+    HavocNamespace::HavocApplication = new HavocNamespace::HavocSpace::Havoc(new QMainWindow);
+    HavocNamespace::HavocApplication->Init(argc, argv);
 
     int AppStatus = QApplication::exec();
 
-    spdlog::info( "Havoc Application status: {}", AppStatus );
+    spdlog::info("Havoc Application status: {}", AppStatus);
 
     return AppStatus;
 }


### PR DESCRIPTION
Added QTimer that reapplies the Monaco font after 10ms to ensure the font is applied regardless of the users Qt5 Settings.

The attached video is an example of an 8 second reapply. Using 10ms appears makes it almost instantaneous without causing any noticeable issues.
https://github.com/HavocFramework/Havoc/assets/20119926/5da11371-e552-4d87-a213-713e04ac829b

