### PR TITLE
Added scroll to Widget and Dialog

### DIFF
--- a/client/Include/Havoc/PythonApi/PythonApi.h
+++ b/client/Include/Havoc/PythonApi/PythonApi.h
@@ -20,6 +20,7 @@ namespace PythonAPI
         {
             PY_FUNCTION( Load )
             PY_FUNCTION( GetDemons )
+            PY_FUNCTION( GetListeners )
             PY_FUNCTION_KW( RegisterCommand )
             PY_FUNCTION( RegisterModule )
             PY_FUNCTION( RegisterCallback )

--- a/client/Include/Havoc/PythonApi/UI/PyDialogClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyDialogClass.hpp
@@ -5,6 +5,7 @@
 #include <global.hpp>
 
 #include <QVBoxLayout>
+#include <QScrollArea>
 #include <QDialog>
 #include <QLabel>
 #include <QPushButton>
@@ -15,8 +16,11 @@
 typedef struct
 {
 
-    QDialog* window;
-    QVBoxLayout* layout;
+    QDialog*        window;
+    QVBoxLayout*    layout;
+    QScrollArea*    scroll;
+    QWidget*        root;
+    QVBoxLayout*    root_layout;
 
 } PyDialogQWindow, *PPyDialogQWindow;
 

--- a/client/Include/Havoc/PythonApi/UI/PyDialogClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyDialogClass.hpp
@@ -12,6 +12,8 @@
 #include <QCheckBox>
 #include <QLineEdit>
 #include <QCalendarWidget>
+#include <QDial>
+#include <QSlider>
 
 typedef struct
 {
@@ -53,5 +55,7 @@ PyObject*   DialogClass_addLineedit( PPyDialogClass self, PyObject *args );
 PyObject*   DialogClass_addCalendar( PPyDialogClass self, PyObject *args );
 PyObject*   DialogClass_replaceLabel( PPyDialogClass self, PyObject *args );
 PyObject*   DialogClass_addImage( PPyDialogClass self, PyObject *args );
+PyObject*   DialogClass_addDial( PPyDialogClass self, PyObject *args );
+PyObject*   DialogClass_addSlider( PPyDialogClass self, PyObject *args );
 
 #endif

--- a/client/Include/Havoc/PythonApi/UI/PyWidgetClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyWidgetClass.hpp
@@ -11,12 +11,16 @@
 #include <QCheckBox>
 #include <QLineEdit>
 #include <QCalendarWidget>
+#include <QScrollArea>
 
 typedef struct
 {
 
-    QWidget* window;
-    QVBoxLayout* layout;
+    QWidget*        window;
+    QVBoxLayout*    layout;
+    QScrollArea*    scroll;
+    QWidget*        root;
+    QVBoxLayout*    root_layout;
 
 } PyWidgetQWindow, *PPyWidgetQWindow;
 

--- a/client/Include/Havoc/PythonApi/UI/PyWidgetClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyWidgetClass.hpp
@@ -12,6 +12,8 @@
 #include <QLineEdit>
 #include <QCalendarWidget>
 #include <QScrollArea>
+#include <QDial>
+#include <QSlider>
 
 typedef struct
 {
@@ -53,5 +55,7 @@ PyObject*   WidgetClass_addCalendar( PPyWidgetClass self, PyObject *args );
 PyObject*   WidgetClass_replaceLabel( PPyWidgetClass self, PyObject *args );
 PyObject*   WidgetClass_clear( PPyWidgetClass self, PyObject *args );
 PyObject*   WidgetClass_addImage( PPyWidgetClass self, PyObject *args );
+PyObject*   WidgetClass_addDial( PPyWidgetClass self, PyObject *args );
+PyObject* WidgetClass_addSlider( PPyWidgetClass self, PyObject *args );
 
 #endif

--- a/client/Source/Havoc/PythonApi/Havoc.cpp
+++ b/client/Source/Havoc/PythonApi/Havoc.cpp
@@ -18,6 +18,7 @@ namespace PythonAPI::Havoc
     PyMethodDef PyMethode_Havoc[] = {
             { "LoadScript",       PythonAPI::Havoc::Core::Load,                            METH_VARARGS,                 "load python script"       },
             { "GetDemons",        PythonAPI::Havoc::Core::GetDemons,                       METH_VARARGS,                 "get list of demon ID's"   },
+            { "GetListeners",     PythonAPI::Havoc::Core::GetListeners,                    METH_VARARGS,                 "get list of Listeners"   },
             { "RegisterCommand",  ( PyCFunction ) PythonAPI::Havoc::Core::RegisterCommand, METH_VARARGS | METH_KEYWORDS, "register a command/alias" },
             { "RegisterModule",   PythonAPI::Havoc::Core::RegisterModule,                  METH_VARARGS,                 "register a module"        },
             { "RegisterCallback", PythonAPI::Havoc::Core::RegisterCallback,                METH_VARARGS,                 "register a callback"      },
@@ -80,6 +81,22 @@ PyObject* PythonAPI::Havoc::Core::Load( PyObject *self, PyObject *args )
     }
 
     Py_RETURN_TRUE;
+}
+
+PyObject* PythonAPI::Havoc::Core::GetListeners( PyObject *self, PyObject *args )
+{
+    auto      Listeners        = HavocX::Teamserver.Listeners;
+    uint32_t  NumberOfSessions = Listeners.size();
+    PyObject* ListenerObjects  = PyList_New( NumberOfSessions );
+    PyObject* ListenerID       = NULL;
+
+    for ( int i = 0; i < NumberOfSessions; ++i )
+    {
+        ListenerID = Py_BuildValue( "s", Listeners[ i ].Name.c_str() );
+        PyList_SetItem( ListenerObjects, i, ListenerID );
+    }
+
+    return ListenerObjects;
 }
 
 PyObject* PythonAPI::Havoc::Core::GetDemons( PyObject *self, PyObject *args )

--- a/client/Source/Havoc/PythonApi/PyAgentClass.cpp
+++ b/client/Source/Havoc/PythonApi/PyAgentClass.cpp
@@ -156,7 +156,7 @@ PyObject* AgentClass_Command( PPyAgentClass self, PyObject *args )
 
     if ( ! PyArg_ParseTuple( args, "ssO", &TaskID, &Name, &CommandArg ) )
         Py_RETURN_NONE;
-        
+
     CommandLen = PyBytes_GET_SIZE( CommandArg );
     CommandArg = PyBytes_AS_STRING( CommandArg );
     Command    = QByteArray( CommandArg, CommandLen );

--- a/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
@@ -90,7 +90,6 @@ void DialogClass_dealloc( PPyDialogClass self )
             delete self->DialogWindow->window;
         if (self->DialogWindow)
             free(self->DialogWindow);
-
         Py_TYPE( self )->tp_free( ( PyObject* ) self );
     }
 }
@@ -127,7 +126,6 @@ int DialogClass_init( PPyDialogClass self, PyObject *args, PyObject *kwds )
         return -1;
     AllocMov( self->title, title, strlen(title) );
 
-    printf("after alloc\n");
     self->DialogWindow->window = new QDialog(HavocX::HavocUserInterface->HavocWindow);
     self->DialogWindow->window->setWindowTitle(title);
 

--- a/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
@@ -188,9 +188,10 @@ PyObject* DialogClass_addImage( PPyDialogClass self, PyObject *args )
 PyObject* DialogClass_addButton( PPyDialogClass self, PyObject *args )
 {
     char *text = nullptr;
+    char *style = nullptr;
     PyObject* button_callback = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO", &text, &button_callback) )
+    if( !PyArg_ParseTuple( args, "sO|s", &text, &button_callback, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -200,6 +201,8 @@ PyObject* DialogClass_addButton( PPyDialogClass self, PyObject *args )
         return NULL;
     }
     QPushButton* button = new QPushButton(text, self->DialogWindow->window);
+    if (style)
+        button->setStyleSheet(style);
     self->DialogWindow->layout->addWidget(button);
     QObject::connect(button, &QPushButton::clicked, self->DialogWindow->window, [button_callback]() {
             PyObject_CallFunctionObjArgs(button_callback, nullptr);
@@ -211,9 +214,10 @@ PyObject* DialogClass_addButton( PPyDialogClass self, PyObject *args )
 PyObject* DialogClass_addCheckbox( PPyDialogClass self, PyObject *args )
 {
     char *text = nullptr;
+    char *style = nullptr;
     PyObject* checkbox_callback = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO", &text, &checkbox_callback) )
+    if( !PyArg_ParseTuple( args, "sO|s", &text, &checkbox_callback, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -223,6 +227,8 @@ PyObject* DialogClass_addCheckbox( PPyDialogClass self, PyObject *args )
         return NULL;
     }
     QCheckBox* checkbox = new QCheckBox(text, self->DialogWindow->window);
+    if (style)
+        checkbox->setStyleSheet(style);
     self->DialogWindow->layout->addWidget(checkbox);
     QObject::connect(checkbox, &QCheckBox::clicked, self->DialogWindow->window, [checkbox_callback]() {
             PyObject_CallFunctionObjArgs(checkbox_callback, nullptr);

--- a/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
@@ -25,6 +25,8 @@ PyMethodDef PyDialogClass_methods[] = {
         { "addCombobox",               ( PyCFunction ) DialogClass_addCombobox,               METH_VARARGS, "Insert a checkbox in the window" },
         { "addLineedit",               ( PyCFunction ) DialogClass_addLineedit,               METH_VARARGS, "Insert a Line edit in the window" },
         { "addCalendar",               ( PyCFunction ) DialogClass_addCalendar,               METH_VARARGS, "Insert a Calendar in the window" },
+        { "addDial",                  ( PyCFunction ) DialogClass_addDial,               METH_VARARGS, "Insert a Dial in the window" },
+        { "addSlider",                  ( PyCFunction ) DialogClass_addSlider,               METH_VARARGS, "Insert a Slider in the window" },
         { "replaceLabel",               ( PyCFunction ) DialogClass_replaceLabel,               METH_VARARGS, "Replace a label with supplied text" },
         { "clear",               ( PyCFunction ) DialogClass_clear,               METH_VARARGS, "clear the dialog" },
 
@@ -318,6 +320,58 @@ PyObject* DialogClass_addCalendar( PPyDialogClass self, PyObject *args )
             PyObject_CallFunctionObjArgs(cal_callback, pyString, nullptr);
     });
 
+    Py_RETURN_NONE;
+}
+
+PyObject* DialogClass_addDial( PPyDialogClass self, PyObject *args )
+{
+    PyObject* cal_callback = nullptr;
+
+    if( !PyArg_ParseTuple( args, "O", &cal_callback) )
+    {
+        Py_RETURN_NONE;
+    }
+    if ( !PyCallable_Check(cal_callback) )
+    {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return NULL;
+    }
+
+    QDial* dial = new QDial(self->DialogWindow->window);
+    self->DialogWindow->layout->addWidget(dial);
+    QObject::connect(dial, &QDial::valueChanged, self->DialogWindow->window, [cal_callback](long value) {
+            PyObject* pyLong = PyLong_FromLong(value);
+            PyObject_CallFunctionObjArgs(cal_callback, pyLong, nullptr);
+    });
+    Py_RETURN_NONE;
+}
+
+PyObject* DialogClass_addSlider( PPyDialogClass self, PyObject *args )
+{
+    PyObject* cal_callback = nullptr;
+    PyObject* vertical = nullptr;
+
+    if( !PyArg_ParseTuple( args, "O|O", &cal_callback, &vertical) )
+    {
+        Py_RETURN_NONE;
+    }
+    if ( !PyCallable_Check(cal_callback) )
+    {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return NULL;
+    }
+
+    QSlider* slider = nullptr;
+    if (vertical && PyBool_Check(vertical) && vertical == Py_True) {
+        slider = new QSlider(Qt::Vertical);
+    } else {
+        slider = new QSlider(Qt::Horizontal);
+    }
+    self->DialogWindow->layout->addWidget(slider);
+    QObject::connect(slider, &QSlider::valueChanged, self->DialogWindow->window, [cal_callback](long value) {
+            PyObject* pyLong = PyLong_FromLong(value);
+            PyObject_CallFunctionObjArgs(cal_callback, pyLong, nullptr);
+    });
     Py_RETURN_NONE;
 }
 

--- a/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
@@ -120,14 +120,17 @@ int DialogClass_init( PPyDialogClass self, PyObject *args, PyObject *kwds )
 {
     char*       title       = NULL;
     PyObject*   scrollable = NULL;
-    const char* kwdlist[]   = { "title", "scrollable", NULL };
+    int         width       = 400;
+    int         height      = 300;
+    const char* kwdlist[]   = { "title", "scrollable", "width", "height", NULL };
 
-    if ( ! PyArg_ParseTupleAndKeywords( args, kwds, "s|O", const_cast<char**>(kwdlist), &title, &scrollable) )
+    if ( ! PyArg_ParseTupleAndKeywords( args, kwds, "s|Oii", const_cast<char**>(kwdlist), &title, &scrollable, &width, &height) )
         return -1;
     AllocMov( self->title, title, strlen(title) );
 
     self->DialogWindow->window = new QDialog(HavocX::HavocUserInterface->HavocWindow);
     self->DialogWindow->window->setWindowTitle(title);
+    self->DialogWindow->window->resize(width, height);
 
     self->DialogWindow->root = new QWidget();
     self->DialogWindow->layout = new QVBoxLayout(self->DialogWindow->root);

--- a/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
@@ -191,9 +191,10 @@ PyObject* WidgetClass_setSmallTab( PPyWidgetClass self, PyObject *args )
 PyObject* WidgetClass_addButton( PPyWidgetClass self, PyObject *args )
 {
     char *text = nullptr;
+    char *style = nullptr;
     PyObject* button_callback = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO", &text, &button_callback) )
+    if( !PyArg_ParseTuple( args, "sO|s", &text, &button_callback, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -203,6 +204,8 @@ PyObject* WidgetClass_addButton( PPyWidgetClass self, PyObject *args )
         return NULL;
     }
     QPushButton* button = new QPushButton(text, self->WidgetWindow->window);
+    if (style)
+        button->setStyleSheet(style);
     self->WidgetWindow->layout->addWidget(button);
     QObject::connect(button, &QPushButton::clicked, self->WidgetWindow->window, [button_callback]() {
             PyObject_CallFunctionObjArgs(button_callback, nullptr);
@@ -214,9 +217,10 @@ PyObject* WidgetClass_addButton( PPyWidgetClass self, PyObject *args )
 PyObject* WidgetClass_addCheckbox( PPyWidgetClass self, PyObject *args )
 {
     char *text = nullptr;
+    char *style = nullptr;
     PyObject* checkbox_callback = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO", &text, &checkbox_callback) )
+    if( !PyArg_ParseTuple( args, "sO|s", &text, &checkbox_callback, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -226,6 +230,8 @@ PyObject* WidgetClass_addCheckbox( PPyWidgetClass self, PyObject *args )
         return NULL;
     }
     QCheckBox* checkbox = new QCheckBox(text, self->WidgetWindow->window);
+    if (style)
+        checkbox->setStyleSheet(style);
     self->WidgetWindow->layout->addWidget(checkbox);
     QObject::connect(checkbox, &QCheckBox::clicked, self->WidgetWindow->window, [checkbox_callback]() {
             PyObject_CallFunctionObjArgs(checkbox_callback, nullptr);

--- a/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
@@ -25,6 +25,8 @@ PyMethodDef PyWidgetClass_methods[] = {
         { "addCombobox",               ( PyCFunction ) WidgetClass_addCombobox,               METH_VARARGS, "Insert a checkbox in the window" },
         { "addLineedit",               ( PyCFunction ) WidgetClass_addLineedit,               METH_VARARGS, "Insert a Line edit in the window" },
         { "addCalendar",               ( PyCFunction ) WidgetClass_addCalendar,               METH_VARARGS, "Insert a Calendar in the window" },
+        { "addDial",               ( PyCFunction ) WidgetClass_addDial,               METH_VARARGS, "Insert a dial in the window" },
+        { "addSlider",               ( PyCFunction ) WidgetClass_addSlider,               METH_VARARGS, "Insert a slider in the window" },
         { "replaceLabel",               ( PyCFunction ) WidgetClass_replaceLabel,               METH_VARARGS, "Replace a label with supplied text" },
         { "clear",               ( PyCFunction ) WidgetClass_clear,               METH_VARARGS, "clear a widget" },
 
@@ -318,6 +320,58 @@ PyObject* WidgetClass_addCalendar( PPyWidgetClass self, PyObject *args )
             PyObject_CallFunctionObjArgs(cal_callback, pyString, nullptr);
     });
 
+    Py_RETURN_NONE;
+}
+
+PyObject* WidgetClass_addDial( PPyWidgetClass self, PyObject *args )
+{
+    PyObject* cal_callback = nullptr;
+
+    if( !PyArg_ParseTuple( args, "O", &cal_callback) )
+    {
+        Py_RETURN_NONE;
+    }
+    if ( !PyCallable_Check(cal_callback) )
+    {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return NULL;
+    }
+
+    QDial* dial = new QDial(self->WidgetWindow->window);
+    self->WidgetWindow->layout->addWidget(dial);
+    QObject::connect(dial, &QDial::valueChanged, self->WidgetWindow->window, [cal_callback](long value) {
+            PyObject* pyLong = PyLong_FromLong(value);
+            PyObject_CallFunctionObjArgs(cal_callback, pyLong, nullptr);
+    });
+    Py_RETURN_NONE;
+}
+
+PyObject* WidgetClass_addSlider( PPyWidgetClass self, PyObject *args )
+{
+    PyObject* cal_callback = nullptr;
+    PyObject* vertical = nullptr;
+
+    if( !PyArg_ParseTuple( args, "O|O", &cal_callback, &vertical) )
+    {
+        Py_RETURN_NONE;
+    }
+    if ( !PyCallable_Check(cal_callback) )
+    {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return NULL;
+    }
+
+    QSlider* slider = nullptr;
+    if (vertical && PyBool_Check(vertical) && vertical == Py_True) {
+        slider = new QSlider(Qt::Vertical);
+    } else {
+        slider = new QSlider(Qt::Horizontal);
+    }
+    self->WidgetWindow->layout->addWidget(slider);
+    QObject::connect(slider, &QSlider::valueChanged, self->WidgetWindow->window, [cal_callback](long value) {
+            PyObject* pyLong = PyLong_FromLong(value);
+            PyObject_CallFunctionObjArgs(cal_callback, pyLong, nullptr);
+    });
     Py_RETURN_NONE;
 }
 


### PR DESCRIPTION
## Changes
 - Dialog and Widget class can now take a Boolean as second argument to allow scroll in case of overflow
 - Buttons can now have an optional thrid argument to change it's style
 - Checkbox also have a third arguement to change it's style
 - Dialog can also have a default width and height set during initialization (default set to 400/300)
## New
 - widgets and dialogs can now have dials
 - widgets and dialogs can now have vertical or horizontal sliders
 - Havoc.getlisteners() -> will return an array of listeners (similar to getdemons)
## Screenshots
### scrollable dialogs
![image](https://github.com/HavocFramework/Havoc/assets/19672114/6dd555af-2093-41e9-a0b2-9525b0dde937)
### scrollable widgets
![image](https://github.com/HavocFramework/Havoc/assets/19672114/cedbb5ef-8995-4386-9dc7-14579387eb50)
### button and checkbox with custom style
![image](https://github.com/HavocFramework/Havoc/assets/19672114/c2c77e8d-e789-4d10-a052-bd25051a1b3d)
### Dial and sliders
![image](https://github.com/HavocFramework/Havoc/assets/19672114/b38a4ee4-3460-4afe-8785-e7aa32643549)
## Sample code
```
#!/usr/bin/env python
# -*- coding: utf-8 -*-
# Made by papi
# Created on: Fri 20 Oct 2023 09:51:04 AM CEST
# test_scroll.py
# Description:

import havocui

abc = havocui.Widget("it is me!", True)

defi = havocui.Dialog("it is me!", True)

def close_defi():
    defi.close()
def add_text2():
    defi.addLabel("new text!")
defi.addButton("styled add text", add_text2, "background-color: blue; color: white; border: 2px solid black;")
defi.addLabel("Press a button to add text!")
def dial_data(num):
    print(num)
defi.addDial(dial_data)
defi.addSlider(dial_data)
defi.addSlider(dial_data, True)
defi.addButton("close", close_defi)

def add_text():
    abc.addLabel("new text!")
abc.addButton("styled add text", add_text, "background-color: blue; color: white; border: 2px solid black;")
abc.addLabel("Press a button to add text!")
abc.addCheckbox("checkme", add_text, "QCheckBox { background-color: yellow; color: blue; }")
abc.addButton("add text", add_text)
abc.addDial(dial_data)
abc.addSlider(dial_data)
abc.addSlider(dial_data, True)

def show_dialog():
    abc.setSmallTab()
def defi_show():
    defi.exec()

havocui.createtab("scroll", "widget scroll test", show_dialog, "open square dialog", defi_show)
```