### PR TITLE
added default values for checkbox, errormessages and onnewsession event

### DIFF
--- a/client/Include/Havoc/PythonApi/PythonApi.h
+++ b/client/Include/Havoc/PythonApi/PythonApi.h
@@ -41,6 +41,7 @@ namespace PythonAPI
         namespace Core
         {
             PY_FUNCTION( MessageBox )
+            PY_FUNCTION( ErrorMessage )
             PY_FUNCTION( CreateTab )
             PY_FUNCTION( InputDialog )
             PY_FUNCTION( OpenFileDialog )

--- a/client/Source/Havoc/PythonApi/Event.cpp
+++ b/client/Source/Havoc/PythonApi/Event.cpp
@@ -69,7 +69,9 @@ PyTypeObject PyEventClass_Type = {
 
 void EventClass_dealloc( PPyEvents self )
 {
-    Py_TYPE( self )->tp_free( ( PyObject* ) self );
+    if (self) {
+        Py_TYPE( self )->tp_free( ( PyObject* ) self );
+    }
 }
 
 PyObject* EventClass_new( PyTypeObject *type, PyObject *args, PyObject *kwds )
@@ -97,8 +99,12 @@ PyObject* EventClass_OnNewSession( PPyEvents self, PyObject *args )
 
     if ( ! PyArg_ParseTuple( args, "O", &Function ) )
         return NULL;
+    if ( ! PyCallable_Check( Function ) ) {
+        PyErr_SetString(PyExc_TypeError, "parameter must be callable");
+        return NULL;
+    }
 
-    // TODO: add Event list to current Teamserver Instance
+    HavocX::Teamserver.RegisteredCallbacks.push_back(Function);
 
     Py_RETURN_NONE;
 }

--- a/client/Source/Havoc/PythonApi/HavocUi.cpp
+++ b/client/Source/Havoc/PythonApi/HavocUi.cpp
@@ -12,11 +12,13 @@
 #include <QColorDialog>
 #include <QProgressDialog>
 #include <QTimer>
+#include <QErrorMessage>
 
 namespace PythonAPI::HavocUI
 {
     PyMethodDef PyMethode_HavocUI[] = {
             { "messagebox", PythonAPI::HavocUI::Core::MessageBox, METH_VARARGS, "Python interface for Havoc Messagebox" },
+            { "errormessage", PythonAPI::HavocUI::Core::ErrorMessage, METH_VARARGS, "Python interface for Havoc Error Message" },
             { "createtab", PythonAPI::HavocUI::Core::CreateTab, METH_VARARGS, "Python interface for Havoc Tabs" },
             { "inputdialog", PythonAPI::HavocUI::Core::InputDialog, METH_VARARGS, "Python interface for Havoc InputDialog" },
             { "openfiledialog", PythonAPI::HavocUI::Core::OpenFileDialog, METH_VARARGS, "Python interface for Havoc InputDialog" },
@@ -98,6 +100,21 @@ PyObject* PythonAPI::HavocUI::Core::MessageBox(PyObject *self, PyObject *args)
     messageBox.setStyleSheet(messageBoxStyleSheets.readAll());
 
     messageBox.exec();
+
+    Py_RETURN_NONE;
+}
+
+PyObject* PythonAPI::HavocUI::Core::ErrorMessage(PyObject *self, PyObject *args)
+{
+    char *message = nullptr;
+
+    if( !PyArg_ParseTuple( args, "s", &message ) )
+    {
+        Py_RETURN_NONE;
+    }
+
+    QErrorMessage* errorMessage = new QErrorMessage(HavocX::HavocUserInterface->HavocWindow);
+    errorMessage->showMessage(message);
 
     Py_RETURN_NONE;
 }

--- a/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyDialogClass.cpp
@@ -221,8 +221,9 @@ PyObject* DialogClass_addCheckbox( PPyDialogClass self, PyObject *args )
     char *text = nullptr;
     char *style = nullptr;
     PyObject* checkbox_callback = nullptr;
+    PyObject* is_checked = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO|s", &text, &checkbox_callback, &style) )
+    if( !PyArg_ParseTuple( args, "sO|Os", &text, &checkbox_callback, &is_checked, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -234,6 +235,8 @@ PyObject* DialogClass_addCheckbox( PPyDialogClass self, PyObject *args )
     QCheckBox* checkbox = new QCheckBox(text, self->DialogWindow->window);
     if (style)
         checkbox->setStyleSheet(style);
+    if (is_checked && PyBool_Check(is_checked) && is_checked == Py_True)
+        checkbox->setChecked(true);
     self->DialogWindow->layout->addWidget(checkbox);
     QObject::connect(checkbox, &QCheckBox::clicked, self->DialogWindow->window, [checkbox_callback]() {
             PyObject_CallFunctionObjArgs(checkbox_callback, nullptr);

--- a/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyWidgetClass.cpp
@@ -221,8 +221,9 @@ PyObject* WidgetClass_addCheckbox( PPyWidgetClass self, PyObject *args )
     char *text = nullptr;
     char *style = nullptr;
     PyObject* checkbox_callback = nullptr;
+    PyObject* is_checked = nullptr;
 
-    if( !PyArg_ParseTuple( args, "sO|s", &text, &checkbox_callback, &style) )
+    if( !PyArg_ParseTuple( args, "sO|Os", &text, &checkbox_callback, &is_checked, &style) )
     {
         Py_RETURN_NONE;
     }
@@ -234,6 +235,8 @@ PyObject* WidgetClass_addCheckbox( PPyWidgetClass self, PyObject *args )
     QCheckBox* checkbox = new QCheckBox(text, self->WidgetWindow->window);
     if (style)
         checkbox->setStyleSheet(style);
+    if (is_checked && PyBool_Check(is_checked) && is_checked == Py_True)
+        checkbox->setChecked(true);
     self->WidgetWindow->layout->addWidget(checkbox);
     QObject::connect(checkbox, &QCheckBox::clicked, self->WidgetWindow->window, [checkbox_callback]() {
             PyObject_CallFunctionObjArgs(checkbox_callback, nullptr);


### PR DESCRIPTION
## Changed
 - Added a default option for checkbox to have them automatically checked
 - Added functionality for the Events to have OnNewSession working
## Added
 - havocui.errormessage("error message") -> error message dialog
![image](https://github.com/HavocFramework/Havoc/assets/19672114/a473d31b-f8f8-4900-9ff8-588bf841a01c)
## test code
```
#!/usr/bin/env python
# -*- coding: utf-8 -*-
# Made by papi
# Created on: Fri 20 Oct 2023 10:11:44 PM CEST
# havoc.py
# Description:

import havoc

def fun_callback(num):
    print("here")
    print(num)

a = havoc.Event('test_event')
a.OnNewSession(fun_callback)

```