### PR TITLE
Fix font issue in Kali

### DIFF
--- a/.github/ISSUE_TEMPLATE/Bug_Report-Demon.yml
+++ b/.github/ISSUE_TEMPLATE/Bug_Report-Demon.yml
@@ -8,14 +8,6 @@ body:
   - type: markdown
     attributes:
       value: "Thanks for taking the time to fill out this bug report!"
-  - type: input
-    id: contact
-    attributes: 
-      label: "Contact Details"
-      description: "How can we get in touch with you if we need more info?"
-      placeholder: "ex. email@example.com"
-    validations: 
-      required: false
   - type: textarea
     id: what-happened
     attributes: 
@@ -26,22 +18,12 @@ body:
     validations: 
       required: true
   - type: dropdown
-    id: version
-    attributes: 
-      label: Did You Do a Pull First?
-      description: "What version of our software are you running?"
-      options: 
-        - "Latest (You performed a pull first)"
-        - "Anything else (You didn't pull...)"
-    validations: 
-      required: true
-  - type: dropdown
     id: branch
     attributes: 
       label: Did You Try With the Dev Branch?
       description: "This branch has the latest features and fixes so it might solve your problem"
       options: 
-        - "Yes (You tried using the dev branch but the problem persist)"
+        - "Yes (You tried using the dev branch but the problem persists)"
         - "No (You only tried the main branch...)"
     validations: 
       required: true

--- a/client/Data/stylesheets/Havoc.qss
+++ b/client/Data/stylesheets/Havoc.qss
@@ -1,3 +1,7 @@
+* {
+  font-family: "Monaco";
+  font-size: 9pt;
+}
 
 QMainWindow {
     background: #313342;

--- a/client/Source/Main.cpp
+++ b/client/Source/Main.cpp
@@ -22,13 +22,6 @@ int main( int argc, char** argv )
         HavocX::DebugMode = true;
     }
 
-    auto FontID = QFontDatabase::addApplicationFont( ":/icons/Monaco" );
-    auto Family = QFontDatabase::applicationFontFamilies( FontID ).at( 0 );
-    auto Monaco = QFont( Family );
-
-    Monaco.setPointSize( 9 );
-    QApplication::setFont( Monaco );
-
     QGuiApplication::setWindowIcon( QIcon( ":/Havoc.ico" ) );
 
     HavocNamespace::HavocApplication = new HavocNamespace::HavocSpace::Havoc( new QMainWindow );


### PR DESCRIPTION
Kali uses qt5ct to configure themes and fonts for qt apps. The font set has priority by the one set in havoc's code.
If you override the variable QT_QPA_PLATFORMTHEME and run havoc client by the command `QT_QPA_PLATFORMTHEME= havoc client` the issue isn't pressent.

I found that by setting the font in Havoc.qss this is respected by qtct

The package in Kali already provides a patch to fix this for now https://gitlab.com/kalilinux/packages/havoc/-/blob/kali/master/debian/patches/fix-monospace-font.patch?ref_type=heads