### PR TITLE
Added a panel to the TreeView to make the three view more useful

### DIFF
--- a/client/Include/Havoc/PythonApi/PyDemonClass.h
+++ b/client/Include/Havoc/PythonApi/PyDemonClass.h
@@ -50,6 +50,7 @@ PyObject*   DemonClass_InlineExecuteGetOutput( PPyDemonClass self, PyObject *arg
 PyObject*   DemonClass_DotnetInlineExecute( PPyDemonClass self, PyObject *args );
 PyObject*   DemonClass_RegisterCallback( PPyDemonClass self, PyObject *args );
 PyObject*   DemonClass_Command( PPyDemonClass self, PyObject *args );
+PyObject* DemonClass_CommandGetOutput( PPyDemonClass self, PyObject *args );
 
 // Utils
 PyObject*   DemonClass_ConsoleWrite( PPyDemonClass self, PyObject *args );

--- a/client/Include/Havoc/PythonApi/UI/PyTreeClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyTreeClass.hpp
@@ -6,17 +6,20 @@
 
 #include <QWidget>
 #include <QVBoxLayout>
+#include <QHBoxLayout>
 #include <QScrollArea>
+#include <QTextEdit>
 #include <QTreeView>
 #include <QStandardItemModel>
 #include <QStandardItem>
+#include <QSplitter>
 
 
 typedef struct
 {
 
     QWidget*            window;
-    QVBoxLayout*        layout;
+    QHBoxLayout*        layout;
     QScrollArea*        scroll;
     QWidget*            root;
     QVBoxLayout*        root_layout;
@@ -24,6 +27,8 @@ typedef struct
     QStandardItemModel* item_model;
     QStandardItem*      root_item;
     QTreeView*          tree_view;
+    QTextEdit*          panel;
+    QSplitter*          splitter;
 
 } PyTreeQWindow, *PPyTreeQWindow;
 
@@ -49,5 +54,6 @@ PyObject* TreeClass_setBottomTab( PPyTreeClass self, PyObject *args );
 PyObject* TreeClass_setSmallTab( PPyTreeClass self, PyObject *args );
 PyObject* TreeClass_addRow( PPyTreeClass self, PyObject *args );
 PyObject* TreeClass_setItem( PPyTreeClass self, PyObject *args );
+PyObject* TreeClass_setPanel( PPyTreeClass self, PyObject *args );
 
 #endif

--- a/client/Include/global.hpp
+++ b/client/Include/global.hpp
@@ -280,6 +280,7 @@ namespace HavocX
     extern bool                                     DebugMode;
     extern bool                                     GateGUI;
     extern PyObject*                                callbackGate;
+    extern PyObject*                                callbackMessage;
     extern HavocNamespace::Util::ConnectionInfo     Teamserver;
     extern HavocNamespace::UserInterface::HavocUI*  HavocUserInterface;
     extern HavocNamespace::Connector*               Connector;

--- a/client/Source/Havoc/Demon/CommandOutput.cpp
+++ b/client/Source/Havoc/Demon/CommandOutput.cpp
@@ -15,9 +15,11 @@ using namespace HavocNamespace::HavocSpace;
 void DispatchOutput::MessageOutput( QString JsonString, const QString& Date = "" ) const
 {
     auto JsonDocument = QJsonDocument::fromJson( QByteArray::fromBase64( JsonString.toLocal8Bit( ) ) );
+    auto TaskID       = JsonDocument[ "TaskID" ].toString();
     auto MessageType  = JsonDocument[ "Type" ].toString();
     auto Message      = JsonDocument[ "Message" ].toString();
     auto Output       = JsonDocument[ "Output" ].toString();
+
 
     if ( Message.length() > 0 )
     {
@@ -35,6 +37,14 @@ void DispatchOutput::MessageOutput( QString JsonString, const QString& Date = ""
 
     if ( ! Output.isEmpty() )
     {
+        printf("task: %s\n", TaskID.toUtf8().constData());
+        if (HavocX::callbackMessage)
+        {
+            PyObject *arglist = Py_BuildValue( "s", Output.toUtf8().constData() );
+            PyObject_CallFunctionObjArgs( HavocX::callbackMessage, arglist, NULL );
+            Py_XDECREF( HavocX::callbackMessage );
+            HavocX::callbackMessage = NULL;
+        }
         this->DemonCommandInstance->DemonConsole->AppendRaw( Output );
     }
 

--- a/client/Source/Havoc/Packager.cpp
+++ b/client/Source/Havoc/Packager.cpp
@@ -744,6 +744,13 @@ bool Packager::DispatchSession( Util::Packager::PPackage Package )
                                 Session.InteractedWidget->Console->verticalScrollBar()->setValue(
                                         Session.InteractedWidget->Console->verticalScrollBar()->maximum()
                                 );
+                                if (HavocX::callbackMessage) {
+                                    auto data = Package->Body.Info[ "Output" ].c_str();
+                                    PyObject *arglist = Py_BuildValue( "s", data );
+                                    PyObject_CallFunctionObjArgs( HavocX::callbackMessage, arglist, NULL );
+                                    Py_XDECREF( HavocX::callbackMessage );
+                                    HavocX::callbackMessage = NULL;
+                                }
                             }
 
                             break;

--- a/client/Source/Havoc/Packager.cpp
+++ b/client/Source/Havoc/Packager.cpp
@@ -744,13 +744,6 @@ bool Packager::DispatchSession( Util::Packager::PPackage Package )
                                 Session.InteractedWidget->Console->verticalScrollBar()->setValue(
                                         Session.InteractedWidget->Console->verticalScrollBar()->maximum()
                                 );
-                                if (HavocX::callbackMessage) {
-                                    auto data = Package->Body.Info[ "Output" ].c_str();
-                                    PyObject *arglist = Py_BuildValue( "s", data );
-                                    PyObject_CallFunctionObjArgs( HavocX::callbackMessage, arglist, NULL );
-                                    Py_XDECREF( HavocX::callbackMessage );
-                                    HavocX::callbackMessage = NULL;
-                                }
                             }
 
                             break;

--- a/client/Source/Havoc/PythonApi/PyDemonClass.cpp
+++ b/client/Source/Havoc/PythonApi/PyDemonClass.cpp
@@ -41,6 +41,7 @@ PyMethodDef PyDemonClass_methods[] = {
         { "DllInject",              ( PyCFunction ) DemonClass_DllInject,              METH_VARARGS, "Injects a reflective dll into a specified process" },
         { "DotnetInlineExecute",    ( PyCFunction ) DemonClass_DotnetInlineExecute,    METH_VARARGS, "Executes a dotnet assembly in the context of the demon sessions" },
         { "Command",                ( PyCFunction ) DemonClass_Command,                METH_VARARGS, "Run a command" },
+        { "CommandGetOutput",       ( PyCFunction ) DemonClass_CommandGetOutput,                METH_VARARGS, "Run a command and retreive the base 64 output" },
 
         { NULL },
 };
@@ -340,6 +341,34 @@ PyObject* DemonClass_Command( PPyDemonClass self, PyObject *args )
     {
         if ( Session.Name.compare( self->DemonID ) == 0 )
         {
+            Session.InteractedWidget->DemonCommands->DispatchCommand( true, TaskID, Command );
+            break;
+        }
+    }
+
+    Py_RETURN_NONE;
+}
+
+PyObject* DemonClass_CommandGetOutput( PPyDemonClass self, PyObject *args )
+{
+    char*   TaskID    = NULL;
+    char*   Command      = NULL;
+    PyObject* Callback   = nullptr;
+
+    if ( ! PyArg_ParseTuple( args, "ssO", &TaskID, &Command, &Callback) )
+        return NULL;
+    if ( ! PyCallable_Check( Callback ) )
+    {
+        spdlog::error( "The callback is not callable" );
+        return nullptr;
+    }
+
+    for ( auto& Session : HavocX::Teamserver.Sessions )
+    {
+        if ( Session.Name.compare( self->DemonID ) == 0 )
+        {
+            HavocX::callbackMessage = Callback;
+            Py_XINCREF(Callback);
             Session.InteractedWidget->DemonCommands->DispatchCommand( true, TaskID, Command );
             break;
         }

--- a/client/Source/Havoc/PythonApi/PyDemonClass.cpp
+++ b/client/Source/Havoc/PythonApi/PyDemonClass.cpp
@@ -41,7 +41,7 @@ PyMethodDef PyDemonClass_methods[] = {
         { "DllInject",              ( PyCFunction ) DemonClass_DllInject,              METH_VARARGS, "Injects a reflective dll into a specified process" },
         { "DotnetInlineExecute",    ( PyCFunction ) DemonClass_DotnetInlineExecute,    METH_VARARGS, "Executes a dotnet assembly in the context of the demon sessions" },
         { "Command",                ( PyCFunction ) DemonClass_Command,                METH_VARARGS, "Run a command" },
-        { "CommandGetOutput",       ( PyCFunction ) DemonClass_CommandGetOutput,                METH_VARARGS, "Run a command and retreive the base 64 output" },
+        { "CommandGetOutput",       ( PyCFunction ) DemonClass_CommandGetOutput,                METH_VARARGS, "Run a command and retreive the output" },
 
         { NULL },
 };
@@ -367,6 +367,13 @@ PyObject* DemonClass_CommandGetOutput( PPyDemonClass self, PyObject *args )
     {
         if ( Session.Name.compare( self->DemonID ) == 0 )
         {
+            //auto TaskID = QString( Util::gen_random( 8 ).c_str() );
+            // TODO: In the future if the Demon returns back the command
+            // ID this section can be changed to a list in the same way
+            // of BOF_callback. Currently there is no way to match a request
+            // to data received for regular commands to we hook the callback
+            // to work with the next one received.
+
             HavocX::callbackMessage = Callback;
             Py_XINCREF(Callback);
             Session.InteractedWidget->DemonCommands->DispatchCommand( true, TaskID, Command );

--- a/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
@@ -235,10 +235,14 @@ PyObject* TreeClass_setPanel( PPyTreeClass self, PyObject *args )
     {
         Py_RETURN_NONE;
     }
-    self->TreeWindow->panel->clear();
+    if (self->TreeWindow->panel) {
+        self->TreeWindow->panel->clear();
 
-    QString Qtext = QString(str);
-    self->TreeWindow->panel->append(Qtext);
+        QString Qtext = QString(str);
+        self->TreeWindow->panel->append(Qtext);
+    } else {
+        PyErr_SetString(PyExc_TypeError, "The tree panel was not activated on initialization");
+    }
 
     Py_RETURN_NONE;
 }

--- a/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
@@ -19,6 +19,7 @@ PyMethodDef PyTreeClass_methods[] = {
         { "setBottomTab",               ( PyCFunction ) TreeClass_setBottomTab,               METH_VARARGS, "Set widget as Bottom Tab" },
         { "setSmallTab",               ( PyCFunction ) TreeClass_setSmallTab,               METH_VARARGS, "Set widget as Small Tab" },
         { "addRow",               ( PyCFunction ) TreeClass_addRow,               METH_VARARGS, "add a row to the tree" },
+        { "setPanel",               ( PyCFunction ) TreeClass_setPanel,               METH_VARARGS, "Set the data inside of the panel" },
         { "setItem",               ( PyCFunction ) TreeClass_setItem,               METH_VARARGS, "set an item in the tree" },
 
         { NULL },
@@ -103,6 +104,7 @@ PyObject* TreeClass_new( PyTypeObject *type, PyObject *args, PyObject *kwds )
     self->TreeWindow->layout = NULL;
     self->TreeWindow->scroll= NULL;
     self->TreeWindow->root = NULL;
+    self->TreeWindow->panel = NULL;
     self->TreeWindow->root_layout = NULL;
     return ( PyObject* ) self;
 }
@@ -111,9 +113,10 @@ int TreeClass_init( PPyTreeClass self, PyObject *args, PyObject *kwds )
 {
     char*       title          = NULL;
     PyObject* class_callback    = nullptr;
-    const char* kwdlist[]        = { "title", "callback", NULL };
+    PyObject* has_panel         = nullptr;
+    const char* kwdlist[]        = { "title", "callback", "panel", NULL };
 
-    if ( ! PyArg_ParseTupleAndKeywords( args, kwds, "sO", const_cast<char**>(kwdlist), &title, &class_callback ) )
+    if ( ! PyArg_ParseTupleAndKeywords( args, kwds, "sO|O", const_cast<char**>(kwdlist), &title, &class_callback, &has_panel ) )
         return -1;
     if ( !PyCallable_Check(class_callback) )
     {
@@ -127,7 +130,7 @@ int TreeClass_init( PPyTreeClass self, PyObject *args, PyObject *kwds )
     self->TreeWindow->window->setWindowTitle(title);
 
     self->TreeWindow->root = new QWidget();
-    self->TreeWindow->layout = new QVBoxLayout(self->TreeWindow->root);
+    self->TreeWindow->layout = new QHBoxLayout(self->TreeWindow->root);
 
     self->TreeWindow->scroll = new QScrollArea(self->TreeWindow->window);
     self->TreeWindow->scroll->setWidgetResizable(true);
@@ -141,10 +144,21 @@ int TreeClass_init( PPyTreeClass self, PyObject *args, PyObject *kwds )
 
     self->TreeWindow->root_item = new QStandardItem(title);
     self->TreeWindow->tree_view = new QTreeView();
+    self->TreeWindow->tree_view->setEditTriggers(QAbstractItemView::NoEditTriggers);
 
     self->TreeWindow->tree_view->setModel(self->TreeWindow->item_model);
     self->TreeWindow->item_model->invisibleRootItem()->appendRow(self->TreeWindow->root_item);
-    self->TreeWindow->layout->addWidget(self->TreeWindow->tree_view);
+
+    if (has_panel && PyBool_Check(has_panel) && has_panel == Py_True) {
+        self->TreeWindow->splitter = new QSplitter();
+        self->TreeWindow->panel = new QTextEdit();
+        self->TreeWindow->panel->setReadOnly(true);
+        self->TreeWindow->splitter->addWidget(self->TreeWindow->tree_view);
+        self->TreeWindow->splitter->addWidget(self->TreeWindow->panel);
+        self->TreeWindow->layout->addWidget(self->TreeWindow->splitter);
+    } else {
+        self->TreeWindow->layout->addWidget(self->TreeWindow->tree_view);
+    }
 
     QObject::connect(self->TreeWindow->tree_view->selectionModel(), &QItemSelectionModel::selectionChanged, [self, class_callback](const QItemSelection &selected, const QItemSelection &deselected) {
         for (const QModelIndex &index : selected.indexes()) {
@@ -210,6 +224,21 @@ PyObject* TreeClass_setItem( PPyTreeClass self, PyObject *args )
     QStandardItem* element = new QStandardItem(str);
 
     self->TreeWindow->item_model->setItem(x, y, element);
+
+    Py_RETURN_NONE;
+}
+
+PyObject* TreeClass_setPanel( PPyTreeClass self, PyObject *args )
+{
+    char *str;
+    if( !PyArg_ParseTuple( args, "s", &str) )
+    {
+        Py_RETURN_NONE;
+    }
+    self->TreeWindow->panel->clear();
+
+    QString Qtext = QString(str);
+    self->TreeWindow->panel->append(Qtext);
 
     Py_RETURN_NONE;
 }

--- a/client/Source/UserInterface/Dialogs/Payload.cpp
+++ b/client/Source/UserInterface/Dialogs/Payload.cpp
@@ -239,11 +239,6 @@ void Payload::buttonGenerate()
                 { "Config",    Config },
             },
     };
-    printf("Agent Type: %s\n", this->ComboAgentType->currentText().toStdString().c_str());
-    printf("Listener: %s\n", this->ComboListener->currentText().toStdString().c_str());
-    printf("Arch: %s\n", this->ComboArch->currentText().toStdString().c_str());
-    printf("Format: %s\n", this->ComboFormat->currentText().toStdString().c_str());
-    printf("Config: %s\n", Config.c_str());
 
     Package->Head = Head;
     Package->Body = Body;

--- a/client/Source/global.cpp
+++ b/client/Source/global.cpp
@@ -21,6 +21,7 @@ HavocNamespace::UserInterface::HavocUI* HavocX::HavocUserInterface;
 bool                                    HavocX::DebugMode = false;
 bool                                    HavocX::GateGUI = false;
 PyObject*                               HavocX::callbackGate = nullptr;
+PyObject*                               HavocX::callbackMessage = nullptr;
 
 QString HavocSpace::Listener::PayloadHTTPS    = "Https";
 QString HavocSpace::Listener::PayloadHTTP     = "Http";


### PR DESCRIPTION
## Changed
- removed printf that should have not been uploaded
- new Tree argument to have a panel
## added
 - Tree().setPanel() -> Function to set the text panel to some HTML
 - havoc.CommandGetOutput() -> run a command and get the output
## sample code
```
import havocui
import havoc

def selected_tree(data):
    tree.setPanel("<h1 style=\"color:blue\">Hello %s</h1>\n<p>hello World</p>" % data)
    print (data)

tree = havocui.Tree("Active Directory Data", selected_tree, True)

tree.addRow("Users", "me", "you", "us")
tree.addRow("Computer", "DC01", "WEB01", "FS01")
tree.setPanel("<h1 style=\"color:blue\">HelloWorld</h1>\n<p>hello World</p>")
tree.setBottomTab()

```
## screenshots
![image](https://github.com/HavocFramework/Havoc/assets/19672114/414841fb-4405-4f05-b873-09d52b410b0a)
