### PR TITLE
Fix about section

### DIFF
--- a/client/Include/Havoc/PythonApi/UI/PyTreeClass.hpp
+++ b/client/Include/Havoc/PythonApi/UI/PyTreeClass.hpp
@@ -9,6 +9,7 @@
 #include <QHBoxLayout>
 #include <QScrollArea>
 #include <QTextEdit>
+#include <QTextBrowser>
 #include <QTreeView>
 #include <QStandardItemModel>
 #include <QStandardItem>
@@ -27,7 +28,7 @@ typedef struct
     QStandardItemModel* item_model;
     QStandardItem*      root_item;
     QTreeView*          tree_view;
-    QTextEdit*          panel;
+    QTextBrowser*          panel;
     QSplitter*          splitter;
 
 } PyTreeQWindow, *PPyTreeQWindow;

--- a/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
+++ b/client/Source/Havoc/PythonApi/UI/PyTreeClass.cpp
@@ -72,7 +72,7 @@ PyTypeObject PyTreeClass_Type = {
     {                                                       \
         des = ( char* ) malloc( size * sizeof( char ) );    \
         memset( des, 0, size );                             \
-        std::strcpy( des, src );                            \
+        std::strncpy( des, src, size );                     \
     }
 
 void TreeClass_dealloc( PPyTreeClass self )
@@ -151,8 +151,10 @@ int TreeClass_init( PPyTreeClass self, PyObject *args, PyObject *kwds )
 
     if (has_panel && PyBool_Check(has_panel) && has_panel == Py_True) {
         self->TreeWindow->splitter = new QSplitter();
-        self->TreeWindow->panel = new QTextEdit();
-        self->TreeWindow->panel->setReadOnly(true);
+        self->TreeWindow->panel = new QTextBrowser();
+        //self->TreeWindow->panel->setOpenLinks(false);
+        self->TreeWindow->panel->setOpenExternalLinks(true);
+        //self->TreeWindow->panel->setReadOnly(true);
         self->TreeWindow->splitter->addWidget(self->TreeWindow->tree_view);
         self->TreeWindow->splitter->addWidget(self->TreeWindow->panel);
         self->TreeWindow->layout->addWidget(self->TreeWindow->splitter);
@@ -239,7 +241,8 @@ PyObject* TreeClass_setPanel( PPyTreeClass self, PyObject *args )
         self->TreeWindow->panel->clear();
 
         QString Qtext = QString(str);
-        self->TreeWindow->panel->append(Qtext);
+        //self->TreeWindow->panel->append(Qtext);
+        self->TreeWindow->panel->setHtml(Qtext);
     } else {
         PyErr_SetString(PyExc_TypeError, "The tree panel was not activated on initialization");
     }

--- a/client/Source/UserInterface/Dialogs/About.cpp
+++ b/client/Source/UserInterface/Dialogs/About.cpp
@@ -30,6 +30,7 @@ About::About( QDialog* dialog )
 
     textBrowser = new QTextBrowser(AboutDialog);
     textBrowser->setObjectName(QString::fromUtf8("textBrowser"));
+    textBrowser->setOpenExternalLinks(true);
 
     gridLayout->addWidget(textBrowser, 1, 0, 1, 3);
     label->setText(QCoreApplication::translate("Dialogs", R"(<html><head/><body><p align="center"><span style=" font-size:22pt;">Havoc</span></p></body></html>)", nullptr));

--- a/client/Source/UserInterface/HavocUI.cpp
+++ b/client/Source/UserInterface/HavocUI.cpp
@@ -532,7 +532,7 @@ void HavocNamespace::UserInterface::HavocUI::ConnectEvents()
 
     QMainWindow::connect( actionAbout, &QAction::triggered, this, [&]() {
         if ( AboutDialog == nullptr ) {
-            AboutDialog = new About( new QDialog );
+            AboutDialog = new About( new QDialog(HavocX::HavocUserInterface->HavocWindow) );
             AboutDialog->setupUi();
         }
 


### PR DESCRIPTION
## Changes
 - Modified the about section to fit the havoc theme
 - Fixed the link in the about section to actually open in a browser
 - Change the Tree python havocui api to use QTextBrowser for more HTML control.
## screenshots
![image](https://github.com/HavocFramework/Havoc/assets/19672114/ce71328e-36c7-47b4-863d-d0ed0fc1e5f1)
![image](https://github.com/HavocFramework/Havoc/assets/19672114/5dc6b071-8b0e-452d-a507-3d5ff232cf82)
