### PR TITLE
Set font via "setStyleSheet"

### DIFF
--- a/client/Source/Main.cpp
+++ b/client/Source/Main.cpp
@@ -23,14 +23,7 @@ int main(int argc, char** argv)
         HavocX::DebugMode = true;
     }
 
-    auto Monaco = QFont("Monospace", 10);  
-    QApplication::setFont(Monaco);
-
-    auto setFontAgain = []() {
-        auto Monaco = QFont("Monospace", 10);  
-        QApplication::setFont(Monaco);
-    };
-    QTimer::singleShot(10, setFontAgain);
+    HavocApp.setStyleSheet("* { font-family: \"Monaco\"; font-size: 10pt; }");
 
     QGuiApplication::setWindowIcon(QIcon(":/Havoc.ico"));
 


### PR DESCRIPTION
In reference to my previous MR https://github.com/HavocFramework/Havoc/pull/422

Setting the font only in Havoc.qss didn't apply it for all windows and dialogs (only the main one), so I found this better solution.