### PR TITLE
Fix:Fix the problem that Windows 2019 Server cannot be displayed

### DIFF
--- a/client/Source/Util/Base.cpp
+++ b/client/Source/Util/Base.cpp
@@ -40,7 +40,7 @@ auto MessageBox( QString Title, QString Text, QMessageBox::Icon Icon ) -> void
 
 auto WinVersionIcon( QString OSVersion, bool High ) -> QIcon
 {
-    if ( OSVersion.startsWith( "Windows 10" ) || OSVersion.startsWith( "Windows Server 2019" ) )
+    if ( OSVersion.startsWith( "Windows 10" ) || OSVersion.startsWith( "Windows Server 2019" )|| OSVersion.startsWith( "Windows 2019 Server" ) )
     {
         spdlog::debug( "OSVersion is Windows 10" );
 


### PR DESCRIPTION
Fix:Fix the problem that Windows 2019 Server cannot be displayed
The operating system version of the client when used is: "Windows 2019 Server". The code is not deleted here, but the conditions are directly added to improve it.
stdout:
[20:00:38] [info] Started "Https" listener
Windows 11
Windows 2019 Server
Windows 2019 Server
