### PR TITLE
ChunkBOFs fix when there are no parameters

### DIFF
--- a/payloads/Demon/src/core/Command.c
+++ b/payloads/Demon/src/core/Command.c
@@ -1143,21 +1143,23 @@ VOID CommandInlineExecute( PPARSER Parser )
         goto CLEANUP;
     }
 
-    ParamsMemFile = GetMemFile( ParamsFileID );
-    if ( ParamsMemFile && ParamsMemFile->IsCompleted )
-    {
-        ArgBuffer = ParamsMemFile->Data;
-        ArgSize   = ParamsMemFile->Size;
-    }
-    else if ( ParamsMemFile && ! ParamsMemFile->IsCompleted )
-    {
-        PRINTF( "ParamsMemFile [%x] was not completed\n", ParamsFileID );
-        goto CLEANUP;
-    }
-    else
-    {
-        PRINTF( "ParamsMemFile [%x] not found\n", ParamsFileID );
-        goto CLEANUP;
+    if ( ParamsFileID != 0 ) {
+        ParamsMemFile = GetMemFile( ParamsFileID );
+        if ( ParamsMemFile && ParamsMemFile->IsCompleted )
+        {
+            ArgBuffer = ParamsMemFile->Data;
+            ArgSize   = ParamsMemFile->Size;
+        }
+        else if ( ParamsMemFile && ! ParamsMemFile->IsCompleted )
+        {
+            PRINTF( "ParamsMemFile [%x] was not completed\n", ParamsFileID );
+            goto CLEANUP;
+        }
+        else
+        {
+            PRINTF( "ParamsMemFile [%x] not found\n", ParamsFileID );
+            goto CLEANUP;
+        }
     }
 
     switch ( Flags )
@@ -1197,7 +1199,10 @@ VOID CommandInlineExecute( PPARSER Parser )
 
 CLEANUP:
     RemoveMemFile( BofFileID );
-    RemoveMemFile( ParamsFileID );
+    if ( ParamsFileID != 0 ) {
+        RemoveMemFile( ParamsFileID );
+    }
+   
 }
 
 VOID CommandInjectDLL( PPARSER Parser )

--- a/teamserver/pkg/agent/demons.go
+++ b/teamserver/pkg/agent/demons.go
@@ -29,11 +29,13 @@ import (
 
 // we upload heavy files to the implant in chunks, so SMB agents can handle the size
 func (a *Agent) UploadMemFileInChunks(FileData []byte) uint32 {
-	var ID uint32
+	var ID uint32 = 0
 	var chunkSize = DEMON_MAX_RESPONSE_LENGTH
 
-	// generate a random ID
-	ID = rand.Uint32()
+	// generate a random ID that is not 0
+	for ID == 0 {
+		ID = rand.Uint32()
+	}
 
 	FileSize := len(FileData)
 	// split the file in chunks of DEMON_MAX_RESPONSE_LENGTH
@@ -694,7 +696,11 @@ func (a *Agent) TaskPrepare(Command int, Info any, Message *map[string]string, C
 
 		BofFileId    = a.UploadMemFileInChunks(ObjectFile)
 		// a BOF can have an entire PE in its parameters, so chunk them
-		ParamsFileId = a.UploadMemFileInChunks(Parameters)
+		if len(Parameters) == 0 {
+			ParamsFileId = 0;
+		} else {
+			ParamsFileId = a.UploadMemFileInChunks(Parameters)
+		}
 
 		if FunctionName, ok = Optional["FunctionName"].(string); !ok {
 			return nil, errors.New("CoffeeLdr: FunctionName not defined")


### PR DESCRIPTION
Hello!

This commit (https://github.com/HavocFramework/Havoc/commit/12025ead0f4431258593a518e2c7a15f2ff3f8ff) breaks BOFs that do not have parameters (like whoami, driversigs, etc ...)

Here is my quick fix that sets ParamsFileID = 0 when there are no parameters. 

Feel free to modify/fix the code.