### PR TITLE
Iterate to next non-null dowloand item instead of breaking for loop

### DIFF
--- a/payloads/Demon/Source/Core/Download.c
+++ b/payloads/Demon/Source/Core/Download.c
@@ -220,7 +220,7 @@ VOID DownloadPush()
             {
                 DownLast->Next = Download->Next;
                 DownloadFree( Download );
-                DownLast = NULL;
+                Download = DownLast->Next;//Iterate to next non-null item Just Like the code `Socket = SkLast->Next;` located in  Socket.c - void SocketCleanDead()  
             }
         }
         else


### PR DESCRIPTION
A logic bug is detailed in comment as follows:
```c
    for ( ;; )
    {
        if ( ! Download )
            break;

        if ( Download->State == DOWNLOAD_STATE_REMOVE )
        {
            /* we are at the beginning. */
            if ( ! DownLast )
            {
                Instance.Downloads = Download->Next;
                DownloadFree( Download );
                Download = NULL;
            }
            else
            {
                DownLast->Next = Download->Next;
                DownloadFree( Download );//  `Download`  will be set to null,and then break the for-loop.Fixing 
                DownLast = NULL;
            }
        }
        else
        {
            DownLast = Download;
            Download = Download->Next;
        }
    }
```
