### PR TITLE
Fix HashEx() to calculate correctly  hash from wide char string

### DIFF
--- a/payloads/Demon/Source/Core/Win32.c
+++ b/payloads/Demon/Source/Core/Win32.c
@@ -40,6 +40,9 @@ ULONG HashEx(
 
             if ( !*Ptr ) {
                 ++Ptr;
+                //We need to reassign the value of `character` after `++Ptr`.
+                //Beacuse `Hash` is calculated from character,not `*Ptr`
+                character = *Ptr;
             }
         }
 


### PR DESCRIPTION

I find that the Value of `H_MODULE_NTDLL` in `Defines.h`  is  0x70e61753,
and the Value of `python ./hash_func.py ntdll.dll` is 0x1edab0ed.
So i do some debug, it turns out that 
```c
ULONG HashEx(
    IN PVOID String,
    IN ULONG Length,
    IN BOOL  Upper
)
```
does not work correctly when   `String` is passed as wide-char string.

In Windows OS, 
```c
const wchar* wstr = L"ntdll.dll";
//is equal to 
char characters[]{0x6e, 0x00, 0x74, 0x00, 0x64, 0x00, 0x6c, 0x00, 0x6c, 0x00, 0x2e, 0x00, 0x64, 0x00, 0x6c, 0x00, 0x6c, 0x00};
``` 
We need to calculate the  `Hash` from  the element of `characters`  which is greater than 0.


The bug is detailed in comment  as follows:
```c
ULONG HashEx(
    IN PVOID String,
    IN ULONG Length,
    IN BOOL  Upper
) {
    ULONG  Hash = HASH_KEY;
    PUCHAR Ptr  = String;

    if ( ! String ) {
        return 0;
    }

    do {
        UCHAR character = *Ptr;

        if ( ! Length ) {
            if ( ! * Ptr ) {
                break;
            }
        } else {
            if ( ( ULONG ) ( C_PTR( Ptr ) - String ) >= Length ) {
                break;
            }

            if ( !*Ptr ) { // Here we encouter the  `*Ptr == 0`  situation. it means character  == 0 at the same time.
                ++Ptr;  //So We should skip this character,and move Ptr to next character.
                // Forgot to reassign character  to *Ptr.  Now character  is still equal to 0.
                //  character = *Ptr; //Reassign to fix it.
            }
        }

        if ( Upper ) {
            if ( character >= 'a' ) {
                character -= 0x20;
            }
        }

        Hash = ( ( Hash << 5 ) + Hash ) + character;

        ++Ptr;
    } while ( TRUE );

    return Hash;
}
```
It will be a plenty of macros to fix in  `Defines.h`,which is not mentiond in this pull request.