### PR TITLE
implement shellcode spawn for the python api

### DIFF
--- a/client/Include/Havoc/PythonApi/PyDemonClass.h
+++ b/client/Include/Havoc/PythonApi/PyDemonClass.h
@@ -48,6 +48,7 @@ PyObject*   DemonClass_DllSpawn( PPyDemonClass self, PyObject *args );
 PyObject*   DemonClass_InlineExecute( PPyDemonClass self, PyObject *args );
 PyObject*   DemonClass_InlineExecuteGetOutput( PPyDemonClass self, PyObject *args );
 PyObject*   DemonClass_DotnetInlineExecute( PPyDemonClass self, PyObject *args );
+PyObject*   DemonClass_ShellcodeSpawn( PPyDemonClass self, PyObject *args );
 
 // Utils
 PyObject*   DemonClass_ConsoleWrite( PPyDemonClass self, PyObject *args );


### PR DESCRIPTION
Implemented shellcode spawn for the python API. Used in the havoc-donut plugin.