### PR TITLE
fix: "Last" field in HavocUI

### DIFF
--- a/client/src/UserInterface/HavocUi.cc
+++ b/client/src/UserInterface/HavocUi.cc
@@ -268,7 +268,12 @@ void HavocNamespace::UserInterface::HavocUi::UpdateSessionsHealth()
             continue;
 
         auto Now  = QDateTime::currentDateTimeUtc();
+        auto backupTimeSpec = session.LastUTC.timeSpec();
+        // switch to UTC TimeSpec before diff
+        session.LastUTC.setTimeSpec(Qt::UTC);
         auto diff = session.LastUTC.secsTo( Now );
+        // switch back previous TimeSpec after diff
+        session.LastUTC.setTimeSpec(backupTimeSpec);
 
         auto seconds = QDateTime::fromTime_t( diff ).toUTC().toString("s");
         auto minutes = QDateTime::fromTime_t( diff ).toUTC().toString("m");


### PR DESCRIPTION
# Timezone issue

If havoc teamserver's timezone differ from havoc client's timezone. The health check will show incorrect information.

## Before

![image](https://github.com/HavocFramework/Havoc/assets/68040445/f64e6713-88f7-40a5-8d22-076fc3648a16)

## After

![image](https://github.com/HavocFramework/Havoc/assets/68040445/ef205e1f-63e7-433b-9a8c-0802f8e3291c)
