### PR TITLE
Host Header Configuration

### DIFF
--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -253,6 +253,7 @@ func (t *Teamserver) Start() {
 				Headers:      listener.Headers,
 				Uris:         listener.Uris,
 				Secure:       listener.Secure,
+				HostHeader:   listener.HostHeader,
 			}
 
 			if listener.Cert != nil {

--- a/teamserver/pkg/handlers/http.go
+++ b/teamserver/pkg/handlers/http.go
@@ -140,6 +140,17 @@ func (h *HTTP) request(ctx *gin.Context) {
 		}
 	}
 
+	if len(h.Config.HostHeader) > 0 {
+		if strings.ToLower(ctx.Request.Host) == strings.ToLower(h.Config.HostHeader) {
+			valid = true
+		} else if strings.ToLower(ctx.Request.Header.Get("X-Forwarded-Host")) == strings.ToLower(h.Config.HostHeader) {
+			valid = true
+		} else {
+			MissingHdr = "Host: " + ctx.Request.Host + "; X-Forwarded-Host: " + ctx.Request.Header.Get("X-Forwarded-Host")
+			valid = false
+		}
+	}
+
 	if valid == false {
 		logger.Warn(fmt.Sprintf("got a request with an invalid header: %s", MissingHdr))
 		h.fake404(ctx)

--- a/teamserver/pkg/profile/config.go
+++ b/teamserver/pkg/profile/config.go
@@ -77,6 +77,7 @@ type ListenerHTTP struct {
 	Headers   []string `yaotl:"Headers,optional"`
 	Uris      []string `yaotl:"Uris,optional"`
 	Secure    bool     `yaotl:"Secure,optional"`
+    HostHeader string  `yaotl:"HostHeader,optional"`
 
 	/* optional sub blocks */
 	Cert     *ListenerHttpCerts    `yaotl:"Cert,block"`


### PR DESCRIPTION
Added Listener HTTP `HostHeader` field to be configurable via profile.

Configuring `Host` header via `Headers` field does not work as expected as the `gin` package parses the `Host` header to `Context.Request.Host` instead of `Context.Request.Header`. The fix is to use existing `HTTPConfig.HostHeader` field from the listener configuration and compare it to `Context.Request.Host`.

As for setup using redirector, the HTTP request `Host` header field could be retrieved from `X-Forwarded-Host` since it is mentioned to be de-facto standard on [mdn web docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-Host)