### PR TITLE
Remove X-Havoc header from fake 404

### DIFF
--- a/teamserver/pkg/handlers/http.go
+++ b/teamserver/pkg/handlers/http.go
@@ -86,7 +86,6 @@ func (h *HTTP) fake404(ctx *gin.Context) {
 	}
 	ctx.Header("Server", "nginx")
 	ctx.Header("Content-Type", "text/html")
-	ctx.Header("X-Havoc", "true")
 	ctx.Writer.Write(html)
 }
 


### PR DESCRIPTION
Since we are faking a ngnix 404 page, remove the X-Havoc header should reduce detection