### PR TITLE
Dev

### DIFF
--- a/client/config_mac.toml
+++ b/client/config_mac.toml
@@ -1,0 +1,22 @@
+[font]
+size   = 15
+family = "Helvetica"
+
+[scripts]
+files = [
+  "Modules/Packer/packer.py",
+  "Modules/InvokeAssembly/invokeassembly.py",
+  "Modules/PowerPick/powerpick.py",
+  "Modules/SituationalAwareness/SituationalAwareness.py",
+  "Modules/Delegation/delegation.py",
+  "Modules/RemoteOps/RemoteOps.py",
+  "Modules/Domaininfo/Domaininfo.py",
+  "Modules/Jump-exec/ScShell/scshell.py",
+  "Modules/Jump-exec/Psexec/psexec.py",
+  "Modules/Jump-exec/WMI/wmi.py",
+  "Modules/nanodump/nanodump.py",
+  "Modules/nanorobeus/nanorobeus.py",
+  "Modules/Bofbelt/bofbelt.py",
+  "Modules/SamDump/samdump.py",
+  "Modules/NoConsolation/no-consolation.py"
+]

--- a/client/src/UserInterface/SmallWidgets/EventViewer.cc
+++ b/client/src/UserInterface/SmallWidgets/EventViewer.cc
@@ -7,6 +7,10 @@ void HavocNamespace::UserInterface::SmallWidgets::EventViewer::setupUi(QWidget *
     if (Widget->objectName().isEmpty())
         Widget->setObjectName(QString::fromUtf8("EventViewerWidget"));
 
+    // Set the initial size for the Event Viewer widget
+    Widget->resize(400, 200); // Initial size
+    Widget->setMinimumSize(400, 200); // Set minimum size to ensure initial size is respected
+
     gridLayout = new QGridLayout(Widget);
     gridLayout->setObjectName(QString::fromUtf8("gridLayout"));
     gridLayout->setContentsMargins(4, 4, 4, 4);
@@ -14,6 +18,7 @@ void HavocNamespace::UserInterface::SmallWidgets::EventViewer::setupUi(QWidget *
     EventViewerConsole = new QTextEdit(Widget);
     EventViewerConsole->setObjectName(QString::fromUtf8("EventViewer"));
     EventViewerConsole->setReadOnly(true);
+    EventViewerConsole->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Expanding); // Allow resizing
 
     gridLayout->addWidget(EventViewerConsole, 0, 0, 1, 1);
 

--- a/exception_mac.hpp
+++ b/exception_mac.hpp
@@ -1,0 +1,142 @@
+//     Copyright Toru Niina 2017.
+// Distributed under the MIT License.
+#ifndef TOML11_EXCEPTION_HPP
+#define TOML11_EXCEPTION_HPP
+
+#include <array>
+#include <string>
+#include <stdexcept>
+#include <cstring>
+
+#include "source_location.hpp"
+
+namespace toml
+{
+
+namespace detail
+{
+
+inline std::string str_error(int errnum)
+{
+    // C++ standard strerror is not thread-safe.
+    // C11 provides thread-safe version of this function, `strerror_s`, but it
+    // is not available in C++.
+    // To avoid using std::strerror, we need to use platform-specific functions.
+    // If none of the conditions are met, it calls std::strerror as a fallback.
+
+#ifdef _MSC_VER // MSVC
+    constexpr std::size_t bufsize = 256;
+    std::array<char, bufsize> buf;
+    buf.fill('\0');
+    const auto result = strerror_s(buf.data(), bufsize, errnum);
+    if(result != 0)
+    {
+        return std::string("strerror_s failed");
+    }
+    else
+    {
+        return std::string(buf.data());
+    }
+#elif defined(__APPLE__) && defined(__MACH__) // macOS
+    constexpr std::size_t bufsize = 256;
+    std::array<char, bufsize> buf;
+    buf.fill('\0');
+    if (strerror_r(errnum, buf.data(), bufsize) != 0)
+    {
+        return std::string("strerror_r failed");
+    }
+    else
+    {
+        return std::string(buf.data());
+    }
+#elif defined(_GNU_SOURCE) // GNU-specific strerror_r
+    constexpr std::size_t bufsize = 256;
+    std::array<char, bufsize> buf;
+    buf.fill('\0');
+    char* result = strerror_r(errnum, buf.data(), bufsize);
+    return std::string(result);
+#elif (defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200112L) || (defined(_XOPEN_SOURCE) && _XOPEN_SOURCE >= 600) // POSIX
+    constexpr std::size_t bufsize = 256;
+    std::array<char, bufsize> buf;
+    buf.fill('\0');
+    if (strerror_r(errnum, buf.data(), bufsize) != 0)
+    {
+        return std::string("strerror_r failed");
+    }
+    else
+    {
+        return std::string(buf.data());
+    }
+#else // fallback
+    return std::strerror(errnum);
+#endif
+}
+
+} // detail
+
+struct file_io_error : public std::runtime_error
+{
+  public:
+    file_io_error(int errnum, const std::string& msg, const std::string& fname)
+        : std::runtime_error(msg + " \"" + fname + "\": " + detail::str_error(errnum)),
+          errno_(errnum)
+    {}
+    int get_errno() const noexcept {return errno_;}
+
+  private:
+    int errno_;
+};
+
+struct exception : public std::exception
+{
+  public:
+    explicit exception(const source_location& loc): loc_(loc) {}
+    virtual ~exception() noexcept override = default;
+    virtual const char* what() const noexcept override {return "";}
+    virtual source_location const& location() const noexcept {return loc_;}
+
+  protected:
+    source_location loc_;
+};
+
+struct syntax_error : public toml::exception
+{
+  public:
+    explicit syntax_error(const std::string& what_arg, const source_location& loc)
+        : exception(loc), what_(what_arg)
+    {}
+    virtual ~syntax_error() noexcept override = default;
+    virtual const char* what() const noexcept override {return what_.c_str();}
+
+  protected:
+    std::string what_;
+};
+
+struct type_error : public toml::exception
+{
+  public:
+    explicit type_error(const std::string& what_arg, const source_location& loc)
+        : exception(loc), what_(what_arg)
+    {}
+    virtual ~type_error() noexcept override = default;
+    virtual const char* what() const noexcept override {return what_.c_str();}
+
+  protected:
+    std::string what_;
+};
+
+struct internal_error : public toml::exception
+{
+  public:
+    explicit internal_error(const std::string& what_arg, const source_location& loc)
+        : exception(loc), what_(what_arg)
+    {}
+    virtual ~internal_error() noexcept override = default;
+    virtual const char* what() const noexcept override {return what_.c_str();}
+
+  protected:
+    std::string what_;
+};
+
+} // toml
+#endif // TOML_EXCEPTION

--- a/makefile
+++ b/makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 ifndef VERBOSE
 .SILENT:
 endif
@@ -32,7 +33,14 @@ client-build:
 	@ git submodule update --init --recursive
 	@ mkdir -p client/Build; cd client/Build; cmake ..
 	@ if [ -d "client/Modules" ]; then echo "Modules installed"; else git clone --recurse-submodules https://github.com/HavocFramework/Modules client/Modules --single-branch --branch `git rev-parse --abbrev-ref HEAD`; fi
-	@ if [ "$(uname)" = "Darwin" ]; then rm client/external/toml/toml/exception.hpp; cp exception_mac.hpp client/external/toml/toml/exception.hpp; fi
+	@ cmake --build client/Build -- -j 4
+
+client-build-mac:
+	@ echo "[*] building client"
+	@ git submodule update --init --recursive
+	@ mkdir -p client/Build; cd client/Build; cmake ..
+	@ if [ -d "client/Modules" ]; then echo "Modules installed"; else git clone --recurse-submodules https://github.com/HavocFramework/Modules client/Modules --single-branch --branch `git rev-parse --abbrev-ref HEAD`; fi
+	@ rm client/external/toml/toml/exception.hpp ; cp exception_mac.hpp client/external/toml/toml/exception.hpp
 	@ cmake --build client/Build -- -j 4
 
 client-cleanup:

--- a/makefile
+++ b/makefile
@@ -27,12 +27,12 @@ ts-cleanup:
 	@ rm -rf ./havoc
 
 # client building and cleanup targets 
-client-build: 
+client-build:
 	@ echo "[*] building client"
 	@ git submodule update --init --recursive
-	@ mkdir client/Build; cd client/Build; cmake ..
+	@ mkdir -p client/Build; cd client/Build; cmake ..
 	@ if [ -d "client/Modules" ]; then echo "Modules installed"; else git clone --recurse-submodules https://github.com/HavocFramework/Modules client/Modules --single-branch --branch `git rev-parse --abbrev-ref HEAD`; fi
-	@ if [[ "$(uname)" == "Darwin" ]]; then rm client/external/toml/toml/exception.hpp; cp exception_mac.hpp client/external/toml/toml/exception.hpp; fi
+	@ if [ "$(uname)" = "Darwin" ]; then rm client/external/toml/toml/exception.hpp; cp exception_mac.hpp client/external/toml/toml/exception.hpp; fi
 	@ cmake --build client/Build -- -j 4
 
 client-cleanup:

--- a/makefile
+++ b/makefile
@@ -32,6 +32,7 @@ client-build:
 	@ git submodule update --init --recursive
 	@ mkdir client/Build; cd client/Build; cmake ..
 	@ if [ -d "client/Modules" ]; then echo "Modules installed"; else git clone --recurse-submodules https://github.com/HavocFramework/Modules client/Modules --single-branch --branch `git rev-parse --abbrev-ref HEAD`; fi
+	@ if [[ "$(uname)" == "Darwin" ]]; then rm client/external/toml/toml/exception.hpp; cp exception_mac.hpp client/external/toml/toml/exception.hpp; fi
 	@ cmake --build client/Build -- -j 4
 
 client-cleanup:


### PR DESCRIPTION
This PR add the command:

make client-build-mac

The main fix is that in GNU Systems strerror_r return a char * but in POSIX systems (like mac) it return an int.

The error happens in toml11 library in file: client/external/toml/toml/exception.hpp

To fix this without using other library I created the file exception_mac.hpp that implement the fix.

If make client-build-mac is run, the file: client/external/toml/toml/exception.hpp is removed and replaced by fixed one: exception_mac.hpp.

This PR also address the font size issue and implement Helvetica as Font Family, Helvetica is included in Mac Fonts Library by default.

Also, the Event Viewer windows was fixed, in Mac this UI element started without size, so I forced it to 400x200 windows and resize automatically the content to that size.

Image of how it look now in Mac.
<img width="1438" alt="Screenshot 2024-06-07 at 16 47 04" src="https://github.com/HavocFramework/Havoc/assets/5799585/b3e05879-f9f7-4a63-9100-a563059c6c78">

To build the client in Mac just clone this PR and run: make client-build-mac
