### PR TITLE
Delimit headers using CRLF during serialization.

### DIFF
--- a/client/src/Havoc/Packager.cc
+++ b/client/src/Havoc/Packager.cc
@@ -238,7 +238,7 @@ bool Packager::DispatchListener( Util::Packager::PPackage Package )
             if ( ListenerInfo.Protocol == Listener::PayloadHTTP.toStdString() )
             {
                 auto Headers = QStringList();
-                for ( auto& header : QString( Package->Body.Info[ "Headers" ].c_str() ).split( ", " ) ) {
+                for ( auto& header : QString( Package->Body.Info[ "Headers" ].c_str() ).split( "\r\n" ) ) {
                     Headers << header;
                 }
 
@@ -376,7 +376,7 @@ bool Packager::DispatchListener( Util::Packager::PPackage Package )
             if ( ListenerInfo.Protocol == Listener::PayloadHTTP.toStdString() )
             {
                 auto Headers = QStringList();
-                for ( auto& header : QString( Package->Body.Info[ "Headers" ].c_str() ).split( ", " ) )
+                for ( auto& header : QString( Package->Body.Info[ "Headers" ].c_str() ).split( "\r\n" ) )
                     Headers << header;
 
                 auto Uris = QStringList();

--- a/client/src/UserInterface/Dialogs/Listener.cc
+++ b/client/src/UserInterface/Dialogs/Listener.cc
@@ -656,7 +656,7 @@ MapStrStr NewListener::Start( Util::ListenerItem Item, bool Edit )
                 if ( i == ( HeadersData.size() - 1 ) )
                     Headers += HeadersData.at( i )->text().toStdString();
                 else
-                    Headers += HeadersData.at( i )->text().toStdString() + ", ";
+                    Headers += HeadersData.at( i )->text().toStdString() + "\r\n";
 
                 delete HeadersData.at( i );
             }

--- a/teamserver/cmd/server/dispatch.go
+++ b/teamserver/cmd/server/dispatch.go
@@ -371,7 +371,7 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 					}
 				}
 
-				for _, s := range strings.Split(pk.Body.Info["Headers"].(string), ", ") {
+				for _, s := range strings.Split(pk.Body.Info["Headers"].(string), "\r\n") {
 					if len(s) > 0 {
 						Headers = append(Headers, s)
 					}
@@ -665,7 +665,7 @@ func (t *Teamserver) DispatchEvent(pk packager.Package) {
 					}
 				}
 
-				for _, s := range strings.Split(pk.Body.Info["Headers"].(string), ", ") {
+				for _, s := range strings.Split(pk.Body.Info["Headers"].(string), "\r\n") {
 					if len(s) > 0 {
 						Headers = append(Headers, s)
 					}

--- a/teamserver/cmd/server/listener.go
+++ b/teamserver/cmd/server/listener.go
@@ -239,7 +239,7 @@ func (t *Teamserver) ListenerAdd(FromUser string, Type int, Config any) packager
 
 		/* Now set the config/info */
 		Info["Hosts"] = strings.Join(Config.(*handlers.HTTP).Config.Hosts, ", ")
-		Info["Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Headers, ", ")
+		Info["Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Headers, "\r\n")
 		Info["Uris"] = strings.Join(Config.(*handlers.HTTP).Config.Uris, ", ")
 
 		/* proxy settings */
@@ -253,7 +253,7 @@ func (t *Teamserver) ListenerAdd(FromUser string, Type int, Config any) packager
 		Info["Secure"] = Config.(*handlers.HTTP).Config.Secure
 		Info["Status"] = Config.(*handlers.HTTP).Active
 
-		Info["Response Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Response.Headers, ", ")
+		Info["Response Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Response.Headers, "\r\n")
 
 		Info["Secure"] = "false"
 		if Config.(*handlers.HTTP).Config.Secure {

--- a/teamserver/cmd/server/teamserver.go
+++ b/teamserver/cmd/server/teamserver.go
@@ -389,7 +389,7 @@ func (t *Teamserver) Start() {
 			HandlerData.HostRotation = Data["HostRotation"].(string)
 			HandlerData.PortBind = Data["PortBind"].(string)
 			HandlerData.UserAgent = Data["UserAgent"].(string)
-			HandlerData.Headers = strings.Split(Data["Headers"].(string), ", ")
+			HandlerData.Headers = strings.Split(Data["Headers"].(string), "\r\n")
 			HandlerData.Uris = strings.Split(Data["Uris"].(string), ", ")
 			HandlerData.BehindRedir = t.Profile.Config.Demon.TrustXForwardedFor
 
@@ -403,7 +403,7 @@ func (t *Teamserver) Start() {
 				switch Data["Response Headers"].(type) {
 
 				case string:
-					HandlerData.Response.Headers = strings.Split(Data["Response Headers"].(string), ", ")
+					HandlerData.Response.Headers = strings.Split(Data["Response Headers"].(string), "\r\n")
 					break
 
 				default:

--- a/teamserver/pkg/events/listeners.go
+++ b/teamserver/pkg/events/listeners.go
@@ -28,7 +28,7 @@ func (listeners) ListenerAdd(FromUser string, Type int, Config any) packager.Pac
 		Package.Body.Info = structs.Map(Config.(*handlers.HTTP).Config)
 
 		Package.Body.Info["Protocol"] = handlers.AGENT_HTTP
-		Package.Body.Info["Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Headers, ", ")
+		Package.Body.Info["Headers"] = strings.Join(Config.(*handlers.HTTP).Config.Headers, "\r\n")
 		Package.Body.Info["Uris"] = strings.Join(Config.(*handlers.HTTP).Config.Uris, ", ")
 
 		/* proxy settings */
@@ -109,7 +109,7 @@ func (listeners) ListenerEdit(Type int, Config any) packager.Package {
 		Package.Body.Info = structs.Map(Config.(*handlers.HTTPConfig))
 
 		Package.Body.Info["Protocol"] = handlers.AGENT_HTTP
-		Package.Body.Info["Headers"] = strings.Join(Config.(*handlers.HTTPConfig).Headers, ", ")
+		Package.Body.Info["Headers"] = strings.Join(Config.(*handlers.HTTPConfig).Headers, "\r\n")
 		Package.Body.Info["Uris"] = strings.Join(Config.(*handlers.HTTPConfig).Uris, ", ")
 
 		// Proxy settings
@@ -129,7 +129,7 @@ func (listeners) ListenerEdit(Type int, Config any) packager.Package {
 		}
 
 		/* response */
-		Package.Body.Info["Response Headers"] = strings.Join(Config.(*handlers.HTTPConfig).Response.Headers, ", ")
+		Package.Body.Info["Response Headers"] = strings.Join(Config.(*handlers.HTTPConfig).Response.Headers, "\r\n")
 
 		delete(Package.Body.Info, "Proxy")
 		delete(Package.Body.Info, "Response")


### PR DESCRIPTION
This fixes an issue when trying to configure listeners with headers that contain a comma.

Previously the code was using `, `  as a delimiter when serializing the config (using split/join). This meant that if the header had a comma followed by a space, then this would be interpreted as a new header.

For example:

```
Cache-Control: no-store, no-cache, must-revalidate, proxy-revalidate, max-age=0
```

Became:

```
Cache-Control: no-store
no-cache
must-revalidate
proxy-revalidate
max-age=0
```

This PR changes the delimiter for header values *only*, to use CRLF (`\r\n`), instead of a comma. CRLF should never be present in a header (since it's already a header delimiter), so this should be safer.

Testing it, it seems ok:

![image](https://github.com/user-attachments/assets/0bef2561-ae8d-42a7-9213-27da664c6738)

![image](https://github.com/user-attachments/assets/91406584-3cdd-4228-bdc2-80155e4016eb)

