### PR TITLE
Correct timestamp for new session event

### DIFF
--- a/client/src/Havoc/Packager.cc
+++ b/client/src/Havoc/Packager.cc
@@ -637,7 +637,7 @@ bool Packager::DispatchSession( Util::Packager::PPackage Package )
             TeamserverTab->SessionTableWidget->NewSessionItem( Agent );
             TeamserverTab->LootWidget->AddSessionSection( Agent.Name );
 
-            auto Time    = QString( Package->Head.Time.c_str() );
+            auto Time    = Agent.First;
             auto Message = "[" + Util::ColorText::Cyan( "*" ) + "]" + " Initialized " + Util::ColorText::Cyan( Agent.Name ) + " :: " + Util::ColorText::Yellow( Agent.User + "@" + Agent.Internal ) + Util::ColorText::Cyan( " (" ) + Util::ColorText::Red( Agent.Computer ) + Util::ColorText::Cyan( ")" );
 
             HavocX::Teamserver.TabSession->SmallAppWidgets->EventViewer->AppendText( Time, Message );


### PR DESCRIPTION
New session events (in Event Viewer) should record the timestamp of the first check-in, rather than the current time.

This PR changes the new session event so that the timestamp records when the agent first *checked-in*, rather than updating the timestamp every time the event is synced (e.g. when the user starts the client).

Before, if you had a load of initial check-in events in the Event Viewer, their timestamps would always show as the current date/time rather than when they first checked-in.

Changing this to `Agent.First` seems to fix it.