### PR TITLE
Add option to create a new teamserver database

### DIFF
--- a/teamserver/cmd/cmd.go
+++ b/teamserver/cmd/cmd.go
@@ -32,6 +32,7 @@ func init() {
 	// server flags
 	CobraServer.Flags().SortFlags = false
 	CobraServer.Flags().StringVarP(&flags.Server.Profile, "profile", "", "", "set havoc teamserver profile")
+	CobraServer.Flags().StringVarP(&flags.Server.Database, "database", "", "false", "set havoc teamserver database (default data/teamserver.db)")
 	CobraServer.Flags().BoolVarP(&flags.Server.Debug, "debug", "", false, "enable debug mode")
 	CobraServer.Flags().BoolVarP(&flags.Server.DebugDev, "debug-dev", "", false, "enable debug mode for developers (compiles the agent with the debug mode/macro enabled)")
 	CobraServer.Flags().BoolVarP(&flags.Server.SendLogs, "send-logs", "", false, "the agent will send logs over http(s) to the teamserver")

--- a/teamserver/cmd/cmd.go
+++ b/teamserver/cmd/cmd.go
@@ -32,7 +32,7 @@ func init() {
 	// server flags
 	CobraServer.Flags().SortFlags = false
 	CobraServer.Flags().StringVarP(&flags.Server.Profile, "profile", "", "", "set havoc teamserver profile")
-	CobraServer.Flags().StringVarP(&flags.Server.Database, "database", "", "false", "set havoc teamserver database (default data/teamserver.db)")
+	CobraServer.Flags().StringVarP(&flags.Server.Database, "database", "", "data/teamserver.db", "set havoc teamserver database")
 	CobraServer.Flags().BoolVarP(&flags.Server.Debug, "debug", "", false, "enable debug mode")
 	CobraServer.Flags().BoolVarP(&flags.Server.DebugDev, "debug-dev", "", false, "enable debug mode for developers (compiles the agent with the debug mode/macro enabled)")
 	CobraServer.Flags().BoolVarP(&flags.Server.SendLogs, "send-logs", "", false, "the agent will send logs over http(s) to the teamserver")

--- a/teamserver/cmd/server.go
+++ b/teamserver/cmd/server.go
@@ -33,7 +33,10 @@ var CobraServer = &cobra.Command{
 			}
 			os.Exit(0)
 		}
-
+		
+		if flags.Server.Database != "" {
+			DatabasePath = (flags.Server.Database)
+		}
 		Server = server.NewTeamserver(DatabasePath)
 		Server.SetServerFlags(flags)
 

--- a/teamserver/cmd/server/types.go
+++ b/teamserver/cmd/server/types.go
@@ -42,6 +42,7 @@ type serverFlags struct {
 	Host string
 	Port string
 
+	Database string
 	Profile  string
 	Verbose  bool
 	Debug    bool


### PR DESCRIPTION
Added new havoc server flag --database to allow users to now specify a database. 

![image](https://github.com/user-attachments/assets/845f18b5-1ad3-4a57-8d7d-27bf6de13c7f)

When the server is ran it will check if the --database flag contains a value, if it does change the DatabasePath to that value, otherwise the default will remain.

![image](https://github.com/user-attachments/assets/55a740c7-1877-4b49-8083-5df493cc9d73)

Example:
No database provided 
![image](https://github.com/user-attachments/assets/753fb795-6c6b-4859-8ea5-58823c9dbfcb)
![image](https://github.com/user-attachments/assets/d824d703-0894-4db3-96e6-02ad5017f91c)

Database specified
![image](https://github.com/user-attachments/assets/8bb492f1-3d84-4e17-ada5-39e08f26b27a)
![image](https://github.com/user-attachments/assets/3cda6286-52d5-4892-b376-ef85ba1ac242)


