### PR TITLE
show progress of submodule update in client-build

### DIFF
--- a/makefile
+++ b/makefile
@@ -29,7 +29,7 @@ ts-cleanup:
 # client building and cleanup targets 
 client-build: 
 	@ echo "[*] building client"
-	@ git submodule update --init --recursive
+	@ git submodule update --init --recursive --progress
 	@ mkdir client/Build; cd client/Build; cmake ..
 	@ if [ -d "client/Modules" ]; then echo "Modules installed"; else git clone https://github.com/HavocFramework/Modules client/Modules --single-branch --branch `git rev-parse --abbrev-ref HEAD`; fi
 	@ cmake --build client/Build -- -j 4


### PR DESCRIPTION
Added the `--progress` flag to the `git submodule update` command, so dummies like me don't think that the command just hangs and not doing anything :)