### PR TITLE
Fix Client UI crash when removing agent in Table View

### DIFF
--- a/client/src/UserInterface/Widgets/SessionGraph.cc
+++ b/client/src/UserInterface/Widgets/SessionGraph.cc
@@ -89,10 +89,10 @@ void GraphWidget::GraphNodeRemove( SessionItem Session )
         {
             GraphScene->removeItem( NodeList[ i ]->Node->NodeEdge );
             GraphScene->removeItem( NodeList[ i ]->Node );
-
-            NodeList.erase( NodeList.begin() + i );
+            
             MainNode->Node->removeChild( NodeList[ i ]->Node );
-
+            NodeList.erase( NodeList.begin() + i );
+            
             /* delete NodeList[ i ]->Node->NodeEdge;
             delete NodeList[ i ]->Node;
             delete NodeList[ i ]; */


### PR DESCRIPTION
There is a bug that causes the client to crash if the user tries to remove an agent from the table view. This is due to a use-after-erase where `MainNode->Node->removeChild( NodeList[ i ]->Node )` is being called after `NodeList.erase( NodeList.begin() + i )`. This can lead to accessing the wrong element or undefined behavior via an out-of-bounds access. 

The change proposed moves the `removeChild` call before the `erase` to ensure operations on `NodeList[i]` are done while the index is valid.